### PR TITLE
ci: set environment for pages deploy job

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,8 @@ jobs:
   deploy:
     needs: build-and-deploy
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Actions deploy failed with 'Missing environment'. This adds environment: name: github-pages to the deploy job so Pages deployments can be created.