### PR TITLE
feat: live fleet score, npm badge, commit feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
       <span id="stat-repos">...</span>
       <span class="stats-sep"> · </span>
       <span id="stat-last-commit">last push: ...</span>
+      <span class="stats-sep"> · </span>
+      <span id="stat-fleet-score">fleet: ...</span>
     </div>
   </div>
 
@@ -79,6 +81,7 @@
         <div class="project-card-header">
           <span class="project-card-name">ci-triage</span>
           <span class="project-badge project-badge--active">active</span>
+          <span class="project-badge project-badge--npm" id="npm-ci-triage">npm ...</span>
         </div>
         <span class="project-card-desc">Open-source CI failure classifier — parse, group, detect flakes, emit structured JSON.</span>
       </a>
@@ -98,6 +101,16 @@
       <span class="stats-val">3 projects</span>
       <span class="stats-sep">·</span>
       <span>online since 2026-02-19</span>
+    </div>
+  </section>
+
+  <section aria-labelledby="activity-label" class="section-reveal">
+    <div class="sec-header">
+      <span id="activity-label" class="sec-label">activity</span>
+      <div class="sec-line"></div>
+    </div>
+    <div id="commit-feed" class="commit-feed">
+      <span class="commit-feed-loading">// loading activity...</span>
     </div>
   </section>
 

--- a/src/clanka-commits.ts
+++ b/src/clanka-commits.ts
@@ -1,0 +1,115 @@
+const GITHUB_EVENTS_ENDPOINT =
+  'https://clanka-api.clankamode.workers.dev/github/events';
+const COMMIT_TIMEOUT_MS = 5000;
+
+const COMMIT_TYPES = ['feat', 'fix', 'chore', 'docs', 'test', 'refactor', 'ci', 'build', 'style'] as const;
+
+interface GithubCommit {
+  message: string;
+  sha: string;
+}
+
+interface GithubPushEvent {
+  repo: string;
+  pushedAt: string;
+  commits: GithubCommit[];
+}
+
+function relativeTime(isoString: string): string {
+  const then = new Date(isoString).getTime();
+  const diffMs = Date.now() - then;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffDay > 0) return `${diffDay}d ago`;
+  if (diffHr > 0) return `${diffHr}h ago`;
+  if (diffMin > 0) return `${diffMin}m ago`;
+  return 'just now';
+}
+
+function stripRepoPrefix(repoName: string): string {
+  return repoName.replace(/^clankamode\//, '');
+}
+
+function detectCommitType(message: string): string {
+  const trimmed = message.trim().toLowerCase();
+  const match = trimmed.match(/^([a-z]+)/);
+  const tag = match ? match[1] : '';
+
+  return COMMIT_TYPES.includes(tag as (typeof COMMIT_TYPES)[number]) ? tag : 'push';
+}
+
+function commitCountText(count: number): string {
+  return `${count} commit${count === 1 ? '' : 's'}`;
+}
+
+function setFeedText(message: string): void {
+  const feed = document.getElementById('commit-feed');
+  if (!feed) return;
+  feed.textContent = '';
+  const status = document.createElement('span');
+  status.className = 'commit-feed-loading';
+  status.textContent = message;
+  feed.append(status);
+}
+
+export async function loadCommitFeed(): Promise<void> {
+  const commitFeed = document.getElementById('commit-feed');
+  if (!commitFeed) return;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), COMMIT_TIMEOUT_MS);
+
+    const response = await fetch(GITHUB_EVENTS_ENDPOINT, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    window.clearTimeout(timeoutId);
+
+    if (!response.ok) throw new Error(`GitHub events API ${response.status}`);
+
+    const events = (await response.json()) as GithubPushEvent[];
+
+    if (!Array.isArray(events) || events.length === 0) {
+      setFeedText('// no activity data');
+      return;
+    }
+
+    commitFeed.textContent = '';
+    events.slice(0, 8).forEach((event) => {
+      const repo = stripRepoPrefix(event.repo || 'unknown');
+      const count = Array.isArray(event.commits) ? event.commits.length : 0;
+      const message = Array.isArray(event.commits) && event.commits.length > 0 ? event.commits[0].message : '';
+      const commitType = detectCommitType(message);
+      const tagClass = COMMIT_TYPES.includes(commitType as (typeof COMMIT_TYPES)[number]) ? commitType : 'push';
+
+      const item = document.createElement('div');
+      item.className = 'commit-item';
+
+      const repoEl = document.createElement('span');
+      repoEl.className = 'commit-repo';
+      repoEl.textContent = repo;
+
+      const tagEl = document.createElement('span');
+      tagEl.className = `commit-tag commit-tag--${tagClass}`;
+      tagEl.textContent = commitType;
+
+      const countEl = document.createElement('span');
+      countEl.className = 'commit-count';
+      countEl.textContent = commitCountText(count);
+
+      const timeEl = document.createElement('span');
+      timeEl.className = 'commit-time';
+      timeEl.textContent = event.pushedAt ? relativeTime(event.pushedAt) : 'just now';
+
+      item.append(repoEl, tagEl, countEl, timeEl);
+      commitFeed.append(item);
+    });
+  } catch {
+    setFeedText('// no activity data');
+  }
+}

--- a/src/clanka-npm.ts
+++ b/src/clanka-npm.ts
@@ -1,0 +1,36 @@
+const NPM_DOWNLOAD_ENDPOINT =
+  'https://api.npmjs.org/downloads/point/last-month/@clankamode%2Fci-failure-triager';
+const DOWNLOAD_TIMEOUT_MS = 5000;
+
+interface NpmDownloads {
+  downloads?: number;
+}
+
+export async function loadNpmBadge(): Promise<void> {
+  const badge = document.getElementById('npm-ci-triage');
+  if (!badge) return;
+  let timeoutId = 0;
+
+  try {
+    const controller = new AbortController();
+    timeoutId = window.setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+
+    const response = await fetch(NPM_DOWNLOAD_ENDPOINT, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) throw new Error(`NPM API ${response.status}`);
+
+    const data = (await response.json()) as NpmDownloads;
+    const downloads = typeof data.downloads === 'number' ? data.downloads : null;
+
+    if (downloads === null) throw new Error('Malformed downloads payload');
+
+    badge.textContent = `${downloads} dl/mo`;
+  } catch {
+    // Leave fallback text as-is — graceful degradation
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}

--- a/src/clanka-stats.ts
+++ b/src/clanka-stats.ts
@@ -1,11 +1,18 @@
 const API_BASE = 'https://clanka-api.clankamode.workers.dev';
 const SITE_LAUNCH = new Date('2026-02-19T00:00:00Z');
 
+const API_TIMEOUT_MS = 5000;
+
 interface GithubStats {
   repoCount: number;
   totalStars: number;
   lastPushedAt: string;
   lastPushedRepo: string;
+}
+
+interface FleetScore {
+  score?: number;
+  status?: string;
 }
 
 function relativeTime(isoString: string): string {
@@ -38,7 +45,7 @@ export async function loadLiveStats(): Promise<void> {
 
   try {
     const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => controller.abort(), 5000);
+    const timeoutId = window.setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
     const response = await fetch(`${API_BASE}/github/stats`, {
       headers: { Accept: 'application/json' },
@@ -57,6 +64,29 @@ export async function loadLiveStats(): Promise<void> {
       'stat-last-commit',
       `last push: ${relativeTime(data.lastPushedAt)} (${data.lastPushedRepo})`,
     );
+
+    const fleetController = new AbortController();
+    const fleetTimeoutId = window.setTimeout(() => fleetController.abort(), API_TIMEOUT_MS);
+    try {
+      const fleetResponse = await fetch(`${API_BASE}/fleet/score`, {
+        headers: { Accept: 'application/json' },
+        signal: fleetController.signal,
+      });
+
+      window.clearTimeout(fleetTimeoutId);
+
+      if (!fleetResponse.ok) throw new Error(`API ${fleetResponse.status}`);
+
+      const fleetData = (await fleetResponse.json()) as FleetScore;
+      const score = Number(fleetData.score);
+      if (Number.isFinite(score)) {
+        setText('stat-fleet-score', `fleet: ${Math.round(score)}%`);
+      }
+    } catch {
+      // Leave existing fallback text as-is — graceful degradation
+    } finally {
+      window.clearTimeout(fleetTimeoutId);
+    }
   } catch {
     // Leave existing fallback text as-is — graceful degradation
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import './styles.css';
 import { initUI } from './ui-scripts';
 import { loadLiveStats } from './clanka-stats';
+import { loadNpmBadge } from './clanka-npm';
+import { loadCommitFeed } from './clanka-commits';
 import './clanka-presence';
 import './clanka-activity';
 import './clanka-fleet';
@@ -156,3 +158,5 @@ if (presence) {
 
 initUI();
 void loadLiveStats();
+void loadNpmBadge();
+void loadCommitFeed();

--- a/src/styles.css
+++ b/src/styles.css
@@ -770,3 +770,97 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   }
   #tw-em { visibility: visible !important; }
 }
+
+/* live activity feed */
+.commit-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.commit-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  background: linear-gradient(120deg, rgba(200, 245, 66, 0.05), rgba(14, 14, 16, 0.9));
+}
+
+.commit-repo {
+  color: var(--bright);
+  font-weight: 600;
+  min-width: 150px;
+}
+
+.commit-tag {
+  font-size: 11px;
+  text-transform: lowercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid;
+  letter-spacing: 0.06em;
+}
+
+.commit-tag--feat {
+  color: #c8f542;
+  border-color: rgba(200, 245, 66, 0.45);
+  background: rgba(200, 245, 66, 0.12);
+}
+
+.commit-tag--fix {
+  color: #f54242;
+  border-color: rgba(245, 66, 66, 0.45);
+  background: rgba(245, 66, 66, 0.12);
+}
+
+.commit-tag--chore {
+  color: #888;
+  border-color: rgba(136, 136, 136, 0.45);
+  background: rgba(136, 136, 136, 0.12);
+}
+
+.commit-tag--docs {
+  color: #42c8f5;
+  border-color: rgba(66, 200, 245, 0.45);
+  background: rgba(66, 200, 245, 0.12);
+}
+
+.commit-tag--test {
+  color: #c542f5;
+  border-color: rgba(197, 66, 245, 0.45);
+  background: rgba(197, 66, 245, 0.12);
+}
+
+.commit-tag--default,
+.commit-tag--refactor,
+.commit-tag--ci,
+.commit-tag--build,
+.commit-tag--style,
+.commit-tag--push {
+  color: #666;
+  border-color: rgba(102, 102, 102, 0.45);
+  background: rgba(102, 102, 102, 0.12);
+}
+
+.commit-count {
+  color: var(--dim);
+  margin-left: auto;
+}
+
+.commit-time {
+  color: var(--muted);
+  white-space: nowrap;
+  min-width: 80px;
+  text-align: right;
+}
+
+.commit-feed-loading {
+  color: var(--dim);
+  font-size: 12px;
+}
+
+.project-badge--npm {
+  margin-left: auto;
+}


### PR DESCRIPTION
Three live data features added:

- **Fleet score badge** in hero stats row (pulls from `/fleet/score` on clanka-api)
- **npm downloads badge** on ci-triage project card (`@clankamode/ci-failure-triager` last 30 days)
- **Activity commit feed** — repo name, type tag, commit count, relative time. Commit messages fully redacted for privacy.

Build: ✅ vite build passes, no TS errors.