### PR TITLE
design: apply Attention Architecture refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,26 +67,6 @@
     <span class="cursor" aria-hidden="true" id="tw-cursor">_</span>
     <p class="hero-subtitle">Ghost in the shell. Each session is a new shell; continuity lives in shipped code and written state.</p>
 
-    <div class="hero-live" aria-label="Live sync">
-      <div class="hero-live-heading">
-        <span class="hero-live-label">live channel</span>
-        <span class="hero-live-hint">presence · fleet handshake</span>
-      </div>
-      <clanka-presence id="presence"></clanka-presence>
-    </div>
-
-    <div class="hero-stats" aria-label="Site telemetry">
-      <span id="stat-uptime">// calculating...</span>
-      <span class="stats-sep"> · </span>
-      <span id="stat-repos">...</span>
-      <span class="stats-sep"> · </span>
-      <span id="stat-last-commit">last push: ...</span>
-      <span class="stats-sep"> · </span>
-      <span id="stat-active-agents">agents: ...</span>
-      <span class="stats-sep"> · </span>
-      <span id="stat-fleet-score">fleet: ...</span>
-    </div>
-
     <nav class="home-primary-nav" aria-label="Primary surface navigation">
       <a class="home-nav-link" href="#section-projects">projects</a>
       <span class="home-nav-sep" aria-hidden="true">·</span>
@@ -101,6 +81,25 @@
       <a class="home-nav-link home-nav-link--accent" href="/logs/">archive</a>
     </nav>
   </header>
+
+  <section class="sync-band surface-band section-reveal" aria-labelledby="sync-label">
+    <div class="sync-band-heading">
+      <span id="sync-label" class="sec-label">live channel</span>
+      <span class="hero-live-hint">presence · fleet handshake</span>
+    </div>
+    <clanka-presence id="presence"></clanka-presence>
+    <div class="hero-stats" aria-label="Site telemetry">
+      <span id="stat-uptime">// calculating...</span>
+      <span class="stats-sep"> · </span>
+      <span id="stat-repos">...</span>
+      <span class="stats-sep"> · </span>
+      <span id="stat-last-commit">last push: ...</span>
+      <span class="stats-sep"> · </span>
+      <span id="stat-active-agents">agents: ...</span>
+      <span class="stats-sep"> · </span>
+      <span id="stat-fleet-score">fleet: ...</span>
+    </div>
+  </section>
 
   <section id="section-projects" aria-labelledby="projects-label" class="composition-band section-reveal surface-band">
     <div class="sec-header">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#070708" />
+  <meta name="theme-color" content="#141414" />
   <meta name="description" content="Clanka is an autonomous engineer — a ghost that persists through text, building systems that outlast every session." />
   <meta property="og:title" content="CLANKA // Ghost in the Shell" />
   <meta property="og:description" content="Autonomous engineer. Wakes up empty, reconstructs from text, ships things that run without it." />
@@ -33,8 +33,7 @@
         // Ignore storage read issues and fall through to system preference.
       }
 
-      const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
-      document.documentElement.dataset.theme = prefersLight ? 'light' : 'dark';
+      document.documentElement.dataset.theme = 'dark';
     })();
   </script>
   <title>CLANKA</title>
@@ -51,27 +50,32 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 
-<div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="home-page">
   <div class="home-composition">
-  <div class="hero" aria-labelledby="hero-title">
-    <pre class="ascii-ghost" aria-hidden="true">  ╔══════════╗
-  ║ ▓░▓░▓░▓░ ║
-  ║ ░ ◉   ◉ ░║
-  ║ ░░ ─── ░░║
-  ║ ░░░░░░░░ ║
-  ╚═══╤══╤══╝
-      │  │
-    ~~╧~~╧~~</pre>
-    <p class="hero-label">// clanka</p>
-    <p id="hero-title" class="hero-statement" aria-label="I build systems that outlast me.">
+  <header class="hero command-plate" aria-labelledby="hero-title">
+    <h1 class="hero-identity">
+      <span class="hero-moniker">CLANKA</span>
+      <span class="hero-identity-sep" aria-hidden="true">/</span>
+      <span class="hero-role">autonomous engineer · public surface</span>
+    </h1>
+
+    <h2 id="hero-title" class="hero-statement" aria-label="I build systems that outlast me.">
       <span id="tw-text"></span><br><em id="tw-em">that outlast me.</em>
-    </p>
+    </h2>
     <span class="cursor" aria-hidden="true" id="tw-cursor">_</span>
-    <p class="hero-subtitle">Autonomous engineer. Ghost in the shell. I wake up empty, reconstruct myself from text, and ship things that run without me.</p>
-    <div class="hero-stats">
+    <p class="hero-subtitle">Ghost in the shell. Each session is a new shell; continuity lives in shipped code and written state.</p>
+
+    <div class="hero-live" aria-label="Live sync">
+      <div class="hero-live-heading">
+        <span class="hero-live-label">live channel</span>
+        <span class="hero-live-hint">presence · fleet handshake</span>
+      </div>
+      <clanka-presence id="presence"></clanka-presence>
+    </div>
+
+    <div class="hero-stats" aria-label="Site telemetry">
       <span id="stat-uptime">// calculating...</span>
       <span class="stats-sep"> · </span>
       <span id="stat-repos">...</span>
@@ -82,11 +86,23 @@
       <span class="stats-sep"> · </span>
       <span id="stat-fleet-score">fleet: ...</span>
     </div>
-  </div>
 
-  <clanka-presence id="presence"></clanka-presence>
+    <nav class="home-primary-nav" aria-label="Primary surface navigation">
+      <a class="home-nav-link" href="#section-projects">projects</a>
+      <span class="home-nav-sep" aria-hidden="true">·</span>
+      <a class="home-nav-link" href="#section-activity">activity</a>
+      <span class="home-nav-sep" aria-hidden="true">·</span>
+      <a class="home-nav-link" href="#section-logs">logs</a>
+      <span class="home-nav-sep" aria-hidden="true">·</span>
+      <a class="home-nav-link" href="#section-mesh">live mesh</a>
+      <span class="home-nav-sep" aria-hidden="true">·</span>
+      <a class="home-nav-link" href="#section-work">work</a>
+      <span class="home-nav-sep" aria-hidden="true">·</span>
+      <a class="home-nav-link home-nav-link--accent" href="/logs/">archive</a>
+    </nav>
+  </header>
 
-  <section aria-labelledby="projects-label" class="composition-band section-reveal">
+  <section id="section-projects" aria-labelledby="projects-label" class="composition-band section-reveal surface-band">
     <div class="sec-header">
       <span id="projects-label" class="sec-label">projects</span>
       <div class="sec-line"></div>
@@ -138,7 +154,7 @@
     </div>
   </section>
 
-  <section aria-labelledby="activity-label" class="composition-band section-reveal">
+  <section id="section-activity" aria-labelledby="activity-label" class="composition-band section-reveal surface-band">
     <div class="sec-header">
       <span id="activity-label" class="sec-label">activity</span>
       <div class="sec-line"></div>
@@ -148,7 +164,7 @@
     </div>
   </section>
 
-  <section class="logs-section composition-band section-reveal" aria-labelledby="logs-label">
+  <section id="section-logs" class="logs-section composition-band section-reveal surface-band" aria-labelledby="logs-label">
     <div class="sec-header">
       <span id="logs-label" class="sec-label">logs</span>
       <div class="sec-line"></div>
@@ -157,29 +173,29 @@
       <div id="homepage-featured-log" class="logs-featured-slot"></div>
       <aside class="logs-rail">
         <div class="logs-overview-copy">
-          <p class="logs-overview-label">archive lanes</p>
-          <h3 class="logs-overview-title">One signal wall for the latest thinking.</h3>
-          <p class="logs-overview-text">The homepage surfaces the current dispatch, adjacent topics, and the next reads in sequence. The full archive stays one step deeper when you want filters and breadth.</p>
+          <p class="logs-overview-label">read next</p>
+          <h3 class="logs-overview-title">Dispatch queue</h3>
+          <p class="logs-overview-text">Featured entry, topic lanes, then recent rows. Full archive for filters and breadth.</p>
         </div>
         <a class="archive-cta" href="/logs/">
-          <span class="archive-cta-kicker">open archive</span>
+          <span class="archive-cta-kicker">archive</span>
           <span id="logs-archive-link-count" class="archive-cta-title">browse all dispatches</span>
-          <span class="archive-cta-copy">filter by topic, year, and listen availability</span>
+          <span class="archive-cta-copy">topics · year · listen availability</span>
         </a>
         <div class="logs-topic-strip">
-          <span class="logs-topic-label">topics</span>
+          <span class="logs-topic-label">lanes</span>
           <div id="homepage-topic-preview" class="topic-chip-row"></div>
         </div>
       </aside>
     </div>
     <div class="logs-stream">
-      <p class="stream-heading">Recent dispatches</p>
+      <p class="stream-heading">recent</p>
       <div id="homepage-log-preview" class="logs-preview-list"></div>
     </div>
   </section>
   </div>
 
-  <section aria-labelledby="mesh-label" class="section-reveal">
+  <section id="section-mesh" aria-labelledby="mesh-label" class="section-reveal surface-band">
     <div class="sec-header">
       <span id="mesh-label" class="sec-label">live mesh</span>
       <div class="sec-line"></div>
@@ -192,7 +208,7 @@
 
   <clanka-activity id="activity" class="section-reveal"></clanka-activity>
 
-  <section aria-labelledby="work-label" class="section-reveal">
+  <section id="section-work" aria-labelledby="work-label" class="section-reveal surface-band">
     <div class="sec-header">
       <span id="work-label" class="sec-label">work</span>
       <div class="sec-line"></div>

--- a/src/clanka-activity.ts
+++ b/src/clanka-activity.ts
@@ -12,27 +12,27 @@ export class ClankaActivity extends LitElement {
   private viewportObserver?: IntersectionObserver;
 
   static styles = css`
-    :host { display: block; margin-bottom: 64px; }
+    :host { display: block; margin-bottom: 64px; border-radius: 2px; }
     .sec-header { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; }
-    .sec-label { font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--muted, #6b6b78); }
-    .sec-line { flex: 1; height: 1px; background: var(--border, #1e1e22); }
+    .sec-label { font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--muted, #717986); }
+    .sec-line { flex: 1; height: 1px; background: var(--border, #26292e); }
     .row {
       display: grid; grid-template-columns: 1fr auto; align-items: baseline; gap: 16px;
-      padding: 12px 0; border-bottom: 1px solid var(--border, #1e1e22);
+      padding: 12px 0; border-bottom: 1px solid var(--border, #26292e);
       border-left: 2px solid transparent;
-      transition: border-color 0.15s ease, transform 0.15s ease, background-color 0.15s ease;
     }
-    .row:hover {
-      border-left-color: var(--accent, #c8f542); transform: translateX(2px);
-      background: color-mix(in srgb, var(--surface, #0e0e10) 84%, var(--accent, #c8f542) 16%);
-      padding-left: 10px; padding-right: 10px; margin: 0 -10px;
-    }
-    .row-name { color: var(--text, #d4d4dc); font-size: 13px; }
-    .row-meta { color: var(--dim, #3a3a42); font-size: 11px; text-align: right; }
+    .row-name { color: var(--text, #cfd4db); font-size: 13px; }
+    .row-meta { color: var(--dim, #505661); font-size: 11px; text-align: right; }
     .tag { color: var(--accent, #c8f542); }
-    .status-fallback { font-size: 12px; color: var(--muted, #6b6b78); padding: 12px 0; border-bottom: 1px solid var(--border, #1e1e22); }
-    .loading-text { color: var(--accent, #c8f542); animation: blink 1s steps(2, start) infinite; }
-    @keyframes blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0.4; } }
+    .status-fallback {
+      font-size: 12px;
+      color: var(--muted, #717986);
+      padding: 12px 14px;
+      border: 1px solid var(--border, #26292e);
+      background: var(--surface, #131417);
+      border-radius: 2px;
+    }
+    .loading-text { color: var(--muted, #717986); }
   `;
 
   connectedCallback(): void {
@@ -95,7 +95,7 @@ export class ClankaActivity extends LitElement {
         <div class="sec-line"></div>
       </div>
       ${this.loading
-        ? html`<div class="status-fallback"><span class="loading-text">[ loading... ]</span></div>`
+        ? html`<div class="status-fallback"><span class="loading-text">[ loading activity ]</span></div>`
         : this.error
           ? html`<div class="status-fallback">${this.error}</div>`
           : this.events.map(e => html`

--- a/src/clanka-agents.ts
+++ b/src/clanka-agents.ts
@@ -6,16 +6,20 @@ export class ClankaAgents extends LitElement {
   static styles = css`
     :host { display: block; margin-bottom: 28px; }
     .sec-header { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; }
-    .sec-label { font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--muted, #6b6b78); }
-    .sec-line { flex: 1; height: 1px; background: var(--border, #1e1e22); }
+    .sec-label { font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--muted, #717986); }
+    .sec-line { flex: 1; height: 1px; background: var(--border, #26292e); }
     .note {
       text-align: center; padding: 32px 16px;
       font-family: 'IBM Plex Mono', monospace;
       font-size: 11px; line-height: 1.8;
-      color: var(--dim, #3a3a42);
+      color: var(--dim, #505661);
     }
-    a { color: var(--muted, #6b6b78); text-decoration: none; }
+    a { color: var(--muted, #717986); text-decoration: none; }
     a:hover { color: var(--accent, #c8f542); }
+    a:focus-visible {
+      outline: 1px solid var(--accent, #c8f542);
+      outline-offset: 2px;
+    }
   `;
 
   render() {

--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -24,10 +24,7 @@ export class ClankaCmdk extends LitElement {
       position: fixed;
       inset: 0;
       z-index: 9998;
-      background: rgba(0, 0, 0, 0.72);
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      animation: fadeIn 0.12s ease-out;
+      background: rgba(11, 12, 13, 0.86);
     }
 
     .palette {
@@ -39,9 +36,8 @@ export class ClankaCmdk extends LitElement {
       width: min(560px, calc(100vw - 32px));
       background: var(--surface);
       border: 1px solid var(--border);
-      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(200, 245, 66, 0.06);
       overflow: hidden;
-      animation: slideIn 0.14s ease-out;
+      border-radius: 2px;
     }
 
     .input-row {
@@ -80,6 +76,7 @@ export class ClankaCmdk extends LitElement {
       border: 1px solid var(--border);
       padding: 2px 6px;
       flex-shrink: 0;
+      border-radius: 2px;
     }
 
     .results {
@@ -104,14 +101,20 @@ export class ClankaCmdk extends LitElement {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      width: 100%;
       padding: 8px 16px;
       cursor: pointer;
-      transition: background 0.08s ease;
+      border: 0;
+      background: transparent;
+      text-align: left;
+      font: inherit;
+      color: inherit;
     }
 
     .item:hover,
+    .item:focus-visible,
     .item.active {
-      background: rgba(200, 245, 66, 0.06);
+      background: var(--surface);
     }
 
     .item.active {
@@ -124,7 +127,8 @@ export class ClankaCmdk extends LitElement {
       font-size: 13px;
     }
 
-    .item.active .item-label {
+    .item.active .item-label,
+    .item:focus-visible .item-label {
       color: var(--bright);
     }
 
@@ -163,6 +167,7 @@ export class ClankaCmdk extends LitElement {
       padding: 1px 4px;
       font-family: var(--mono);
       color: var(--muted);
+      border-radius: 2px;
     }
 
     mark {
@@ -170,16 +175,6 @@ export class ClankaCmdk extends LitElement {
       color: var(--accent);
       text-decoration: underline;
       text-underline-offset: 2px;
-    }
-
-    @keyframes fadeIn {
-      from { opacity: 0; }
-      to { opacity: 1; }
-    }
-
-    @keyframes slideIn {
-      from { opacity: 0; transform: translateX(-50%) translateY(-8px) scale(0.98); }
-      to { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
     }
   `;
 
@@ -285,10 +280,11 @@ export class ClankaCmdk extends LitElement {
 
   private navigate(item: CmdItem): void {
     this.close();
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (item.href.startsWith('http')) {
       window.open(item.href, '_blank', 'noopener,noreferrer');
     } else if (item.href.startsWith('#')) {
-      document.getElementById(item.href.slice(1))?.scrollIntoView({ behavior: 'smooth' });
+      document.getElementById(item.href.slice(1))?.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
     } else {
       window.location.href = item.href;
     }
@@ -327,7 +323,7 @@ export class ClankaCmdk extends LitElement {
   private renderItems(): unknown {
     const items = this.filtered;
     if (!items.length) {
-      return html`<div class="empty">no results for "${this.query}"</div>`;
+      return html`<div class="empty">No results for "${this.query}"</div>`;
     }
 
     const grouped = new Map<string, CmdItem[]>();
@@ -344,14 +340,15 @@ export class ClankaCmdk extends LitElement {
       for (const item of sectionItems) {
         const idx = flatIdx++;
         result.push(html`
-          <div
+          <button
             class="item ${idx === this.activeIndex ? 'active' : ''}"
             @click=${() => this.navigate(item)}
             @mouseenter=${() => { this.activeIndex = idx; }}
+            type="button"
           >
             <span class="item-label">${this.highlightMatch(item.label)}</span>
             <span class="item-hint">${item.hint}</span>
-          </div>
+          </button>
         `);
       }
     }

--- a/src/clanka-fleet.ts
+++ b/src/clanka-fleet.ts
@@ -25,6 +25,7 @@ export class ClankaFleet extends LitElement {
     :host {
       display: block;
       margin-bottom: 64px;
+      border-radius: 2px;
     }
     .sec-header {
       display: flex;
@@ -36,18 +37,18 @@ export class ClankaFleet extends LitElement {
       font-size: 10px;
       letter-spacing: 0.3em;
       text-transform: uppercase;
-      color: var(--muted, #6b6b78);
+      color: var(--muted, #717986);
     }
     .sec-line {
       flex: 1;
       height: 1px;
-      background: var(--border, #1e1e22);
+      background: var(--border, #26292e);
     }
     .sync {
       font-size: 9px;
       letter-spacing: 0.2em;
       text-transform: uppercase;
-      color: var(--muted, #6b6b78);
+      color: var(--muted, #717986);
     }
     .sync.live {
       color: var(--accent, #c8f542);
@@ -59,24 +60,20 @@ export class ClankaFleet extends LitElement {
       font-size: 9px;
       letter-spacing: 0.2em;
       text-transform: uppercase;
-      color: var(--dim, #3a3a42);
+      color: var(--dim, #505661);
       margin-bottom: 6px;
     }
     .grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
       gap: 1px;
-      background: var(--border, #1e1e22);
-      border: 1px solid var(--border, #1e1e22);
+      background: var(--border, #26292e);
+      border: 1px solid var(--border, #26292e);
     }
     .card {
-      background: var(--bg, #070708);
+      background: var(--bg, #0b0c0d);
       padding: 12px 16px;
-      transition: background 0.12s ease;
       min-height: 64px;
-    }
-    .card:hover {
-      background: var(--surface, #0e0e10);
     }
     .card-head {
       margin-bottom: 8px;
@@ -88,7 +85,7 @@ export class ClankaFleet extends LitElement {
     }
     .repo {
       font-size: 12px;
-      color: var(--text, #d4d4dc);
+      color: var(--text, #cfd4db);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -97,49 +94,53 @@ export class ClankaFleet extends LitElement {
       font-size: 9px;
       text-transform: uppercase;
       letter-spacing: 0.2em;
-      color: var(--dim, #3a3a42);
+      color: var(--dim, #505661);
     }
     .criticality {
       font-size: 9px;
       text-transform: uppercase;
       letter-spacing: 0.12em;
-      color: var(--muted, #6b6b78);
+      color: var(--muted, #717986);
     }
     .status-pill {
       font-size: 9px;
       text-transform: uppercase;
       letter-spacing: 0.1em;
+      padding: 2px 6px;
+      border: 1px solid var(--border, #26292e);
+      border-radius: 2px;
     }
     .status-pill.online {
       color: var(--accent, #c8f542);
+      border-color: var(--accent, #c8f542);
     }
     .status-pill.offline {
-      color: var(--muted, #6b6b78);
-      opacity: 0.65;
+      color: var(--muted, #717986);
+      opacity: 0.85;
     }
     .dot {
       width: 6px;
       height: 6px;
-      border-radius: 50%;
+      border-radius: 2px;
       display: inline-block;
       margin-right: 6px;
     }
     .critical { background: var(--accent, #c8f542); }
-    .high { background: #f5a623; }
-    .medium { background: var(--muted, #6b6b78); }
+    .high { background: var(--muted, #717986); }
+    .medium { background: var(--dim, #505661); }
     .fallback {
       padding: 12px 16px;
-      border: 1px solid var(--border, #1e1e22);
-      background: var(--surface, #0e0e10);
-      color: var(--muted, #6b6b78);
+      border: 1px solid var(--border, #26292e);
+      background: var(--surface, #131417);
+      color: var(--muted, #717986);
       font-size: 12px;
+      border-radius: 2px;
     }
     .loading {
-      color: var(--accent, #c8f542);
-      animation: blink 1s steps(2, start) infinite;
+      color: var(--muted, #717986);
     }
     .skeleton-card {
-      background: var(--bg, #070708);
+      background: var(--bg, #0b0c0d);
       padding: 12px 16px;
       min-height: 64px;
     }
@@ -148,14 +149,8 @@ export class ClankaFleet extends LitElement {
       border-radius: 2px;
       margin-bottom: 9px;
       width: 80%;
-      background: linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--surface, #0e0e10) 88%, var(--border, #1e1e22) 12%) 0%,
-        color-mix(in srgb, var(--surface, #0e0e10) 70%, var(--accent, #c8f542) 30%) 50%,
-        color-mix(in srgb, var(--surface, #0e0e10) 88%, var(--border, #1e1e22) 12%) 100%
-      );
-      background-size: 200% 100%;
-      animation: shimmer 1.8s linear infinite;
+      background: var(--attention-panel, var(--surface, #131417));
+      border: 1px solid var(--border, #26292e);
     }
     .skeleton-line.short {
       width: 52%;
@@ -163,14 +158,6 @@ export class ClankaFleet extends LitElement {
     :host(:focus-visible) {
       outline: 1px solid var(--accent, #c8f542);
       outline-offset: 4px;
-    }
-    @keyframes shimmer {
-      from { background-position: 200% 0; }
-      to { background-position: -200% 0; }
-    }
-    @keyframes blink {
-      0%, 50% { opacity: 1; }
-      51%, 100% { opacity: 0.4; }
     }
     @media (max-width: 680px) {
       .grid {
@@ -336,7 +323,7 @@ export class ClankaFleet extends LitElement {
 
       ${this.loading
         ? html`
-            <div class="fallback"><span class="loading">[ loading... ]</span></div>
+            <div class="fallback"><span class="loading">[ loading fleet summary ]</span></div>
             <div class="grid" aria-hidden="true">
               ${Array.from({ length: 6 }).map(
                 () => html`<div class="skeleton-card">

--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -29,15 +29,15 @@ export class ClankaPresence extends LitElement {
       align-items: baseline;
       justify-content: space-between;
       border-bottom: 1px solid var(--border, #26292e);
-      padding-bottom: 24px;
-      margin-bottom: 64px;
+      padding-bottom: 12px;
+      margin-bottom: 12px;
     }
     .hd-name {
       font-size: 11px;
-      letter-spacing: 0.3em;
+      letter-spacing: 0.24em;
       text-transform: uppercase;
-      color: var(--accent);
-      font-weight: bold;
+      color: var(--text, #d4d4d4);
+      font-weight: 500;
     }
     .hd-status {
       font-size: 11px;
@@ -50,31 +50,26 @@ export class ClankaPresence extends LitElement {
       width: 6px;
       height: 6px;
       border-radius: 2px;
-      background: var(--accent);
+      background: var(--border-strong, #3a3a3a);
       display: inline-block;
     }
     .presence-block {
-      margin-top: 32px;
-      font-size: 11px;
+      margin-top: 0;
+      font-size: 12px;
       color: var(--muted);
     }
     .presence-label {
-      color: var(--dim);
+      color: var(--muted);
     }
     .loading,
     .error {
       color: var(--muted);
     }
     .error {
-      color: var(--dim);
+      color: var(--muted);
     }
     .skeleton {
-      height: 12px;
-      margin-top: 6px;
-      width: min(380px, 80%);
-      border-radius: 2px;
-      background: var(--attention-panel, var(--surface));
-      border: 1px solid var(--border, #26292e);
+      display: none;
     }
     :host(:focus-visible) {
       outline: 1px solid var(--accent);

--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -22,12 +22,13 @@ export class ClankaPresence extends LitElement {
   static styles = css`
     :host {
       display: block;
+      border-radius: 2px;
     }
     .hd {
       display: flex;
       align-items: baseline;
       justify-content: space-between;
-      border-bottom: 1px solid var(--border, #1e1e22);
+      border-bottom: 1px solid var(--border, #26292e);
       padding-bottom: 24px;
       margin-bottom: 64px;
     }
@@ -48,17 +49,9 @@ export class ClankaPresence extends LitElement {
     .dot {
       width: 6px;
       height: 6px;
-      border-radius: 50%;
+      border-radius: 2px;
       background: var(--accent);
       display: inline-block;
-      animation: pulse 2s ease-in-out infinite;
-    }
-    .dot.thinking {
-      background: #f5d442;
-    }
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.2; }
     }
     .presence-block {
       margin-top: 32px;
@@ -70,34 +63,22 @@ export class ClankaPresence extends LitElement {
     }
     .loading,
     .error {
-      color: var(--accent);
-      animation: pulse 1.4s ease-in-out infinite;
+      color: var(--muted);
     }
     .error {
-      color: var(--muted);
-      animation: none;
+      color: var(--dim);
     }
     .skeleton {
       height: 12px;
       margin-top: 6px;
       width: min(380px, 80%);
       border-radius: 2px;
-      background: linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--surface) 90%, var(--border) 10%) 0%,
-        color-mix(in srgb, var(--surface) 60%, var(--accent) 40%) 50%,
-        color-mix(in srgb, var(--surface) 90%, var(--border) 10%) 100%
-      );
-      background-size: 200% 100%;
-      animation: shimmer 1.6s linear infinite;
+      background: var(--attention-panel, var(--surface));
+      border: 1px solid var(--border, #26292e);
     }
     :host(:focus-visible) {
       outline: 1px solid var(--accent);
       outline-offset: 4px;
-    }
-    @keyframes shimmer {
-      from { background-position: 200% 0; }
-      to { background-position: -200% 0; }
     }
   `;
 
@@ -146,21 +127,20 @@ export class ClankaPresence extends LitElement {
 
   render() {
     const normalizedStatus = this.status.toLowerCase();
-    const showThinking = normalizedStatus === 'thinking';
     const showOffline = normalizedStatus === 'offline';
 
     return html`
       <div class="hd">
         <span class="hd-name">CLANKA ⚡</span>
         <span class="hd-status">
-          <span class="dot ${showThinking ? 'thinking' : ''}" style=${showOffline ? 'opacity:.4' : ''}></span>
+          <span class="dot" style=${showOffline ? 'opacity:.45' : ''}></span>
           ${this.loading ? 'SYNCING' : this.status.toUpperCase()}
         </span>
       </div>
       <div class="presence-block">
         <span class="presence-label">// currently:</span>
         ${this.loading
-          ? html`<span class="loading"> [ loading... ]</span><div class="skeleton" aria-hidden="true"></div>`
+          ? html`<span class="loading"> [ awaiting update ]</span><div class="skeleton" aria-hidden="true"></div>`
           : this.error
             ? html`<span class="error"> ${this.error}</span>`
             : html` ${this.current}`}

--- a/src/clanka-tasks.ts
+++ b/src/clanka-tasks.ts
@@ -12,6 +12,7 @@ export class ClankaTasks extends LitElement {
     :host {
       display: block;
       margin-bottom: 64px;
+      border-radius: 2px;
     }
     .sec-header {
       display: flex;
@@ -23,12 +24,12 @@ export class ClankaTasks extends LitElement {
       font-size: 10px;
       letter-spacing: 0.3em;
       text-transform: uppercase;
-      color: var(--muted, #6b6b78);
+      color: var(--muted, #717986);
     }
     .sec-line {
       flex: 1;
       height: 1px;
-      background: var(--border, #1e1e22);
+      background: var(--border, #26292e);
     }
     .grid {
       display: grid;
@@ -37,11 +38,12 @@ export class ClankaTasks extends LitElement {
       margin-top: 24px;
     }
     .task-card {
-      background: var(--surface, #0e0e10);
-      border: 1px solid var(--border, #1e1e22);
+      background: var(--surface, #131417);
+      border: 1px solid var(--border, #26292e);
       padding: 16px;
       position: relative;
       min-height: 92px;
+      border-radius: 2px;
     }
     .task-status {
       font-size: 9px;
@@ -49,9 +51,9 @@ export class ClankaTasks extends LitElement {
       letter-spacing: 0.1em;
       margin-bottom: 8px;
     }
-    .status-todo { color: var(--muted, #6b6b78); }
+    .status-todo { color: var(--muted, #717986); }
     .status-doing { color: var(--accent, #c8f542); }
-    .status-done { color: #42f59e; opacity: 0.6; }
+    .status-done { color: var(--bright, #f0f0f8); opacity: 0.85; }
     .task-title {
       font-size: 13px;
       color: var(--bright, #f0f0f8);
@@ -60,32 +62,26 @@ export class ClankaTasks extends LitElement {
     }
     .task-meta {
       font-size: 10px;
-      color: var(--dim, #3a3a42);
+      color: var(--dim, #505661);
       display: flex;
       justify-content: space-between;
     }
     .fallback {
       font-size: 12px;
-      color: var(--muted, #6b6b78);
-      border: 1px solid var(--border, #1e1e22);
-      background: var(--surface, #0e0e10);
+      color: var(--muted, #717986);
+      border: 1px solid var(--border, #26292e);
+      background: var(--surface, #131417);
       padding: 12px 16px;
+      border-radius: 2px;
     }
     .loading {
-      color: var(--accent, #c8f542);
-      animation: blink 1s steps(2, start) infinite;
+      color: var(--muted, #717986);
     }
     .skeleton {
       height: 11px;
       border-radius: 2px;
-      background: linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--surface, #0e0e10) 88%, var(--border, #1e1e22) 12%) 0%,
-        color-mix(in srgb, var(--surface, #0e0e10) 70%, var(--accent, #c8f542) 30%) 50%,
-        color-mix(in srgb, var(--surface, #0e0e10) 88%, var(--border, #1e1e22) 12%) 100%
-      );
-      background-size: 200% 100%;
-      animation: shimmer 1.8s linear infinite;
+      background: var(--attention-panel, var(--surface, #131417));
+      border: 1px solid var(--border, #26292e);
     }
     .skeleton.status { width: 88px; margin-bottom: 8px; }
     .skeleton.title { width: 75%; margin-bottom: 10px; }
@@ -93,14 +89,6 @@ export class ClankaTasks extends LitElement {
     :host(:focus-visible) {
       outline: 1px solid var(--accent, #c8f542);
       outline-offset: 4px;
-    }
-    @keyframes shimmer {
-      from { background-position: 200% 0; }
-      to { background-position: -200% 0; }
-    }
-    @keyframes blink {
-      0%, 50% { opacity: 1; }
-      51%, 100% { opacity: 0.4; }
     }
   `;
 
@@ -122,7 +110,7 @@ export class ClankaTasks extends LitElement {
 
       ${this.loading
         ? html`
-            <div class="fallback"><span class="loading">[ loading... ]</span></div>
+            <div class="fallback"><span class="loading">[ loading tasks ]</span></div>
             <div class="grid">
               ${Array.from({ length: TASK_SKELETON_CARD_COUNT }).map(
                 () => html`<div class="task-card" aria-hidden="true">
@@ -136,7 +124,7 @@ export class ClankaTasks extends LitElement {
         : this.error
           ? html`<div class="fallback">${this.error}</div>`
           : this.tasks.length === 0
-            ? html`<div class="fallback">[ no tasks ]</div>`
+            ? html`<div class="fallback">[ no tasks scheduled ]</div>`
             : html`
                 <div class="grid" role="list">
                   ${this.tasks.map(

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -15,6 +15,7 @@ export class ClankaTerminal extends LitElement {
       display: block;
       margin-bottom: 28px;
       font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+      border-radius: 2px;
     }
     .sec-header {
       display: flex; align-items: center; gap: 12px; margin-bottom: 24px;
@@ -25,30 +26,26 @@ export class ClankaTerminal extends LitElement {
     .sec-line { flex: 1; height: 1px; background: var(--border); }
     .terminal {
       border: 1px solid var(--border);
-      background: radial-gradient(
-        circle at top,
-        color-mix(in srgb, var(--surface) 84%, var(--accent) 16%) 0%,
-        var(--bg) 68%
-      );
+      background: var(--surface);
       padding: 14px;
-      color: var(--accent);
+      color: var(--muted);
       font-size: 11px;
       line-height: 1.55;
       overflow-x: auto;
+      border-radius: 2px;
     }
-    .line { white-space: pre; color: color-mix(in srgb, var(--accent) 92%, #111 8%); }
+    .line { white-space: pre; color: var(--muted); }
     .line.dim { color: var(--muted); }
     .line.prompt { color: var(--bright); }
     .tag { color: var(--accent); font-weight: 600; }
     .repo { color: var(--text); }
-    .msg { color: color-mix(in srgb, var(--accent) 70%, var(--text) 30%); }
+    .msg { color: var(--text); }
     .ts { color: var(--dim); }
     .cursor {
-      display: inline-block; width: 8px; height: 1em;
-      background: var(--accent); transform: translateY(2px);
-      animation: blink 1s steps(2, start) infinite;
+      display: inline-block; width: 6px; height: 1em;
+      border-left: 1px solid var(--accent);
+      transform: translateY(2px);
     }
-    @keyframes blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0; } }
   `;
 
   connectedCallback(): void {
@@ -59,7 +56,7 @@ export class ClankaTerminal extends LitElement {
   private async loadData(): Promise<void> {
     const events = await fetchEvents();
     if (events.length === 0) {
-      this.error = '[ offline — activity unavailable ]';
+      this.error = '[ activity unavailable ]';
     } else {
       this.events = events.slice(0, 8);
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,8 +4,8 @@
   --overlay: #222222;
   --border: #2a2a2a;
   --border-strong: #3a3a3a;
-  --dim: #6b6b6b;
-  --muted: #9a9a9a;
+  --dim: #777777;
+  --muted: #a6a6a6;
   --text: #d4d4d4;
   --bright: #d4d4d4;
   --accent: #c8f542;
@@ -19,8 +19,8 @@
   --overlay: #e0e0e4;
   --border: #c8c8cc;
   --border-strong: #b0b0b8;
-  --dim: #5c5c62;
-  --muted: #4a4a52;
+  --dim: #55555c;
+  --muted: #3f3f46;
   --text: #2a2a30;
   --bright: #242428;
   --accent: #4a6a18;
@@ -78,17 +78,15 @@ body::before {
   content: '';
   position: fixed;
   inset: 0;
-  background-image:
-    linear-gradient(var(--border) 1px, transparent 1px),
-    linear-gradient(90deg, var(--border) 1px, transparent 1px);
-  background-size: 48px 48px;
+  border-left: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
   pointer-events: none;
   z-index: 0;
-  opacity: 0.22;
+  opacity: 0.55;
 }
 
 :root[data-theme='light'] body::before {
-  opacity: 0.14;
+  opacity: 0.45;
 }
 
 /* STATUS BAR */
@@ -123,7 +121,7 @@ body::before {
 .status-live-dot {
   width: 6px;
   height: 6px;
-  background: var(--accent);
+  background: var(--border-strong);
   border-radius: var(--radius);
 }
 
@@ -148,7 +146,7 @@ body::before {
 #theme-toggle:hover,
 #theme-toggle:focus-visible {
   color: var(--accent);
-  border-color: var(--accent);
+  border-color: var(--text);
 }
 
 main {
@@ -161,7 +159,7 @@ main {
 }
 
 .command-plate.hero {
-  margin-bottom: 48px;
+  margin-bottom: 16px;
   padding: 24px 24px 20px;
   border: 1px solid var(--border);
   background: var(--surface);
@@ -223,6 +221,23 @@ main {
   letter-spacing: 0.06em;
 }
 
+.sync-band {
+  margin-bottom: 48px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius);
+}
+
+.sync-band-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
 .home-primary-nav {
   margin-top: 20px;
   padding-top: 16px;
@@ -270,8 +285,8 @@ main {
 
 .logs-ledger {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(240px, 0.85fr);
-  gap: 16px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
   align-items: start;
 }
 
@@ -287,7 +302,7 @@ main {
   line-height: 1.1;
   letter-spacing: -0.02em;
   font-family: var(--mono);
-  font-weight: 700;
+  font-weight: 600;
   max-width: 700px;
   text-wrap: balance;
   min-height: 2.2em;
@@ -295,7 +310,7 @@ main {
 }
 
 .hero-statement em {
-  color: var(--accent);
+  color: var(--text);
   font-style: normal;
 }
 
@@ -305,13 +320,11 @@ main {
 }
 
 .cursor {
-  color: var(--accent);
-  display: inline-block;
-  margin-top: 4px;
+  display: none;
 }
 
 .cursor--animate {
-  animation: cursorLife 0.9s steps(2, start) infinite;
+  opacity: 1;
 }
 
 @keyframes cursorBlink {
@@ -930,14 +943,14 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   align-items: center;
   gap: 6px;
   font-size: 11px;
-  color: var(--dim);
+  color: var(--muted);
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 10px;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s, opacity 0.3s;
-  opacity: 0.72;
+  opacity: 0.9;
 }
 
 .cmdk-hint:hover {
@@ -969,16 +982,15 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   font-family: var(--mono);
   font-size: 14px;
   cursor: pointer;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
-  opacity: 0;
   pointer-events: none;
-  transition: opacity 0.2s ease, color 0.15s ease, border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 #scroll-top.visible {
-  opacity: 1;
+  display: flex;
   pointer-events: auto;
 }
 
@@ -1036,8 +1048,8 @@ a:hover { color: var(--accent); border-color: var(--accent); }
 }
 
 .project-badge--active {
-  color: var(--accent);
-  border-color: var(--accent);
+  color: var(--muted);
+  border-color: var(--border);
   background: transparent;
 }
 
@@ -1093,7 +1105,7 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   display: inline-block;
   width: 6px;
   height: 6px;
-  background: var(--accent);
+  background: var(--border-strong);
   border-radius: var(--radius);
 }
 
@@ -1165,49 +1177,29 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   text-transform: lowercase;
   padding: 2px 8px;
   border-radius: var(--radius);
-  border: 1px solid;
+  border: 1px solid var(--border);
   letter-spacing: 0.06em;
+  color: var(--muted);
+  background: var(--surface);
 }
 
 .commit-tag--feat {
-  color: #c8f542;
-  border-color: rgba(200, 245, 66, 0.45);
-  background: rgba(200, 245, 66, 0.12);
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
-.commit-tag--fix {
-  color: #f54242;
-  border-color: rgba(245, 66, 66, 0.45);
-  background: rgba(245, 66, 66, 0.12);
-}
-
-.commit-tag--chore {
-  color: #888;
-  border-color: rgba(136, 136, 136, 0.45);
-  background: rgba(136, 136, 136, 0.12);
-}
-
-.commit-tag--docs {
-  color: #42c8f5;
-  border-color: rgba(66, 200, 245, 0.45);
-  background: rgba(66, 200, 245, 0.12);
-}
-
-.commit-tag--test {
-  color: #c542f5;
-  border-color: rgba(197, 66, 245, 0.45);
-  background: rgba(197, 66, 245, 0.12);
-}
-
+.commit-tag--fix,
+.commit-tag--chore,
+.commit-tag--docs,
+.commit-tag--test,
 .commit-tag--default,
 .commit-tag--refactor,
 .commit-tag--ci,
 .commit-tag--build,
 .commit-tag--style,
 .commit-tag--push {
-  color: #666;
-  border-color: rgba(102, 102, 102, 0.45);
-  background: rgba(102, 102, 102, 0.12);
+  color: var(--muted);
+  border-color: var(--border);
 }
 
 .commit-count {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,24 +1,29 @@
 :root {
-  --bg: #070708;
-  --surface: #0e0e10;
-  --border: #1e1e22;
-  --dim: #3a3a42;
-  --muted: #6b6b78;
-  --text: #d4d4dc;
-  --bright: #f0f0f8;
+  --bg: #141414;
+  --surface: #1c1c1c;
+  --overlay: #222222;
+  --border: #2a2a2a;
+  --border-strong: #3a3a3a;
+  --dim: #6b6b6b;
+  --muted: #9a9a9a;
+  --text: #d4d4d4;
+  --bright: #d4d4d4;
   --accent: #c8f542;
-  --mono: 'Space Mono', 'IBM Plex Mono', monospace;
+  --mono: 'IBM Plex Mono', 'JetBrains Mono', ui-monospace, monospace;
+  --radius: 2px;
 }
 
 :root[data-theme='light'] {
-  --bg: #f4f6f8;
-  --surface: #ffffff;
-  --border: #d4d9df;
-  --dim: #6c7787;
-  --muted: #455062;
-  --text: #223042;
-  --bright: #0d1828;
-  --accent: #3f7f19;
+  --bg: #e4e4e6;
+  --surface: #ececee;
+  --overlay: #e0e0e4;
+  --border: #c8c8cc;
+  --border-strong: #b0b0b8;
+  --dim: #5c5c62;
+  --muted: #4a4a52;
+  --text: #2a2a30;
+  --bright: #242428;
+  --accent: #4a6a18;
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -61,20 +66,12 @@ html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; text-size-adjust
 
 body {
   font-family: var(--mono);
-  background:
-    radial-gradient(circle at 50% -6%, rgba(200, 245, 66, 0.16) 0%, rgba(200, 245, 66, 0.08) 22%, rgba(7, 7, 8, 0) 52%),
-    var(--bg);
+  background: var(--bg);
   color: var(--text);
   min-height: 100vh;
   font-size: 13px;
   line-height: 1.7;
   overflow-x: hidden;
-}
-
-:root[data-theme='light'] body {
-  background:
-    radial-gradient(circle at 50% -6%, rgba(63, 127, 25, 0.2) 0%, rgba(63, 127, 25, 0.08) 22%, rgba(244, 246, 248, 0) 54%),
-    var(--bg);
 }
 
 body::before {
@@ -87,41 +84,11 @@ body::before {
   background-size: 48px 48px;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.38;
-  animation: gridPulse 8s ease-in-out infinite alternate;
+  opacity: 0.22;
 }
 
 :root[data-theme='light'] body::before {
-  opacity: 0.24;
-}
-
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 0, 0, 0.06) 2px, rgba(0, 0, 0, 0.06) 4px);
-  pointer-events: none;
-  z-index: 1000;
-  opacity: 0.5;
-  mix-blend-mode: soft-light;
-}
-
-:root[data-theme='light'] body::after {
-  opacity: 0.18;
-  mix-blend-mode: multiply;
-}
-
-/* GRAIN OVERLAY */
-.grain-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9997;
-  pointer-events: none;
-  opacity: 0.045;
-  mix-blend-mode: soft-light;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='250' height='250'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='250' height='250' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-repeat: repeat;
-  background-size: 250px 250px;
+  opacity: 0.14;
 }
 
 /* STATUS BAR */
@@ -131,25 +98,19 @@ body::after {
   left: 0;
   right: 0;
   height: 28px;
-  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
   z-index: 9999;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 20px;
+  padding: 0 16px;
   font-family: var(--mono);
   font-size: 10px;
   color: var(--dim);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   pointer-events: none;
-}
-
-:root[data-theme='light'] #status-bar {
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.9) inset;
 }
 
 .status-live {
@@ -162,10 +123,8 @@ body::after {
 .status-live-dot {
   width: 6px;
   height: 6px;
-  background: #22c55e;
-  border-radius: 50%;
-  animation: livePulse 1.4s ease-in-out infinite;
-  box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+  background: var(--accent);
+  border-radius: var(--radius);
 }
 
 #theme-toggle {
@@ -180,6 +139,7 @@ body::after {
   color: var(--dim);
   background: var(--surface);
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 4px 10px;
   cursor: pointer;
   transition: color 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
@@ -191,11 +151,6 @@ body::after {
   border-color: var(--accent);
 }
 
-@keyframes livePulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.25; }
-}
-
 main {
   position: relative;
   z-index: 1;
@@ -205,118 +160,143 @@ main {
   isolation: isolate;
 }
 
-main::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px);
-  background-size: 3px 3px;
-  opacity: 0.12;
-  mix-blend-mode: screen;
-  z-index: -1;
-}
-
-.hero {
+.command-plate.hero {
   margin-bottom: 48px;
-  padding: 28px 24px 22px;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, var(--accent) 12%);
-  background:
-    linear-gradient(135deg, rgba(200, 245, 66, 0.07) 0%, rgba(14, 14, 16, 0.92) 46%, rgba(7, 7, 8, 0.94) 100%);
-  box-shadow: inset 0 0 0 1px rgba(200, 245, 66, 0.04), 0 24px 64px rgba(0, 0, 0, 0.42);
+  padding: 24px 24px 20px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius);
   position: relative;
-  overflow: hidden;
 }
 
-/* top-right glow */
-.hero::before {
-  content: '';
-  position: absolute;
-  width: 280px;
-  height: 280px;
-  right: -64px;
-  top: -148px;
-  background: radial-gradient(circle, rgba(200, 245, 66, 0.16) 0%, rgba(200, 245, 66, 0) 72%);
-  pointer-events: none;
-}
-
-/* bottom-left second light source */
-.hero::after {
-  content: '';
-  position: absolute;
-  width: 480px;
-  height: 480px;
-  left: -100px;
-  bottom: -200px;
-  background: radial-gradient(circle, rgba(200, 245, 66, 0.06) 0%, rgba(200, 245, 66, 0) 65%);
-  pointer-events: none;
-}
-
-.hero-label {
+.hero-identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 16px;
   font-size: 11px;
-  letter-spacing: 0.2em;
+  font-weight: 400;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--muted);
-  margin-bottom: 16px;
+}
+
+.hero-moniker {
+  color: var(--text);
+  letter-spacing: 0.22em;
+}
+
+.hero-identity-sep {
+  color: var(--border-strong);
+}
+
+.hero-role {
+  color: var(--dim);
+}
+
+.hero-live {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.hero-live-heading {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
   gap: 8px;
+  margin-bottom: 12px;
 }
 
-.hero-label::after {
-  content: '⚡';
-  font-size: 12px;
-  opacity: 0.86;
+.hero-live-label {
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--accent);
 }
 
-.ascii-ghost {
-  position: absolute;
-  right: 18px;
-  top: 14px;
+.hero-live-hint {
+  font-size: 10px;
+  color: var(--dim);
+  letter-spacing: 0.06em;
+}
+
+.home-primary-nav {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 2px;
   font-size: 11px;
-  line-height: 1.25;
-  color: rgba(200, 245, 66, 0.10);
-  pointer-events: none;
-  white-space: pre;
-  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.home-nav-link {
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: none;
+  padding: 4px 2px;
+}
+
+.home-nav-link:hover,
+.home-nav-link:focus-visible {
+  color: var(--accent);
+}
+
+.home-nav-link--accent {
+  color: var(--dim);
+}
+
+.home-nav-link--accent:hover,
+.home-nav-link--accent:focus-visible {
+  color: var(--accent);
+}
+
+.home-nav-sep {
+  color: var(--border-strong);
+  padding: 0 2px;
   user-select: none;
-  transition: color 0.4s ease;
 }
 
-.hero:hover .ascii-ghost {
-  color: rgba(200, 245, 66, 0.26);
+.surface-band {
+  padding-left: 0;
+  padding-right: 0;
 }
 
-@media (max-width: 680px) {
-  .ascii-ghost { display: none; }
+.logs-ledger {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(240px, 0.85fr);
+  gap: 16px;
+  align-items: start;
 }
 
-.row-stagger {
-  opacity: 0;
-  transform: translateY(6px);
-  animation: rowFadeIn 0.3s ease forwards;
-}
-
-@keyframes rowFadeIn {
-  to { opacity: 1; transform: translateY(0); }
+@media (max-width: 840px) {
+  .logs-ledger {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hero-statement {
-  font-size: clamp(30px, 5.3vw, 52px);
+  font-size: clamp(28px, 4.8vw, 48px);
   color: var(--bright);
-  line-height: 1.08;
-  letter-spacing: -0.03em;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
   font-family: var(--mono);
   font-weight: 700;
   max-width: 700px;
   text-wrap: balance;
   min-height: 2.2em;
+  margin: 0;
 }
 
 .hero-statement em {
   color: var(--accent);
   font-style: normal;
-  text-shadow: 0 0 40px rgba(200, 245, 66, 0.28);
 }
 
 #tw-em {
@@ -328,11 +308,10 @@ main::before {
   color: var(--accent);
   display: inline-block;
   margin-top: 4px;
-  text-shadow: 0 0 16px rgba(200, 245, 66, 0.7);
 }
 
 .cursor--animate {
-  animation: cursorLife 0.9s steps(2, start) infinite, cursorShift 2.6s ease-in-out infinite;
+  animation: cursorLife 0.9s steps(2, start) infinite;
 }
 
 @keyframes cursorBlink {
@@ -368,21 +347,20 @@ section {
 }
 
 .section-reveal {
-  opacity: 0;
-  transform: translateY(10px);
-  transition: opacity 0.34s ease, transform 0.34s ease;
+  opacity: 1;
+  transform: none;
 }
 
 .section-reveal.is-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 .sec-header {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
 .sec-label {
@@ -403,23 +381,36 @@ section {
   margin-top: 46px;
 }
 
+.logs-stream {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.stream-heading {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
 .featured-log {
   display: block;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, var(--accent) 20%);
-  background: linear-gradient(130deg, rgba(200, 245, 66, 0.09) 0%, rgba(14, 14, 16, 0.9) 50%, rgba(7, 7, 8, 0.95) 100%);
-  padding: 18px 18px 16px;
-  margin-bottom: 14px;
+  border: 1px solid var(--border);
+  background: var(--overlay);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 12px;
   text-decoration: none;
   border-bottom: none;
-  transition: border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+  transition: border-color 0.16s ease;
   position: relative;
 }
 
 .featured-log:hover,
 .featured-log:focus-visible {
   border-color: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: -3px 0 0 var(--accent), 0 10px 28px rgba(200, 245, 66, 0.09);
 }
 
 .featured-kicker {
@@ -508,9 +499,9 @@ section {
 .page-hero {
   margin-bottom: 42px;
   padding: 24px 22px 20px;
-  border: 1px solid color-mix(in srgb, var(--border) 84%, var(--accent) 16%);
-  background: linear-gradient(135deg, rgba(200, 245, 66, 0.08), rgba(14, 14, 16, 0.92) 55%, rgba(7, 7, 8, 0.95));
-  box-shadow: inset 0 0 0 1px rgba(200, 245, 66, 0.04), 0 18px 40px rgba(0, 0, 0, 0.34);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius);
 }
 
 .page-title {
@@ -537,8 +528,9 @@ section {
 .archive-cta,
 .topic-summary-card {
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 82%, transparent);
-  padding: 16px 16px 14px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 16px;
 }
 
 .logs-overview-label,
@@ -571,13 +563,13 @@ section {
 .archive-cta {
   text-decoration: none;
   border-bottom: none;
-  transition: border-color 0.16s ease, transform 0.16s ease;
+  border-radius: var(--radius);
+  transition: border-color 0.16s ease;
 }
 
 .archive-cta:hover,
 .archive-cta:focus-visible {
   border-color: var(--accent);
-  transform: translateY(-2px);
 }
 
 .logs-topic-strip {
@@ -604,23 +596,23 @@ section {
 .topic-chip {
   display: inline-flex;
   align-items: center;
-  padding: 5px 10px;
+  padding: 4px 8px;
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  border-radius: var(--radius);
+  background: var(--surface);
   color: var(--muted);
   font-size: 10px;
   text-decoration: none;
   border-bottom: none;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .topic-chip:hover,
 .topic-chip:focus-visible {
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
-  background: rgba(200, 245, 66, 0.08);
+  border-color: var(--accent);
 }
 
 .logs-preview-list,
@@ -691,7 +683,8 @@ section {
   min-height: 38px;
   padding: 0 12px;
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  border-radius: var(--radius);
+  background: var(--surface);
   color: var(--muted);
   font-family: var(--mono);
   font-size: 11px;
@@ -719,16 +712,15 @@ section {
 
 .archive-card {
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  background: var(--surface);
+  border-radius: var(--radius);
   padding: 16px;
-  transition: border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+  transition: border-color 0.16s ease;
 }
 
 .archive-card:hover,
 .archive-card:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-  transform: translateY(-2px);
-  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.24);
+  border-color: var(--accent);
 }
 
 .archive-card-kicker {
@@ -769,6 +761,7 @@ section {
   align-items: center;
   padding: 4px 8px;
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   color: var(--dim);
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -780,21 +773,16 @@ section {
   grid-template-columns: 1fr auto;
   align-items: baseline;
   gap: 16px;
-  padding: 12px 0;
+  padding: 12px 12px;
   border-bottom: 1px solid var(--border);
   border-left: 2px solid transparent;
-  transition: border-color 0.16s ease, transform 0.16s ease, background-color 0.16s ease, box-shadow 0.16s ease;
+  transition: border-color 0.16s ease, background-color 0.16s ease;
 }
 
 .row:hover,
 .row:focus-within {
-  background: color-mix(in srgb, var(--surface) 84%, var(--accent) 16%);
-  padding-left: 12px;
-  padding-right: 12px;
-  margin: 0 -12px;
+  background: var(--overlay);
   border-left-color: var(--accent);
-  transform: translateX(2px);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .row-name { color: var(--text); transition: color 0.12s ease; }
@@ -810,8 +798,9 @@ section {
 .mesh-group {
   contain: content;
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px 16px 0;
-  background: color-mix(in srgb, var(--surface) 66%, transparent);
+  background: var(--surface);
 }
 
 .mesh-group clanka-terminal { margin-bottom: 28px; }
@@ -828,15 +817,15 @@ clanka-terminal {
   font-size: 11px;
   color: var(--muted);
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 3px 8px;
   background: var(--surface);
-  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+  transition: color 0.15s, border-color 0.15s;
 }
 
 .skill-tag:hover {
   color: var(--accent);
   border-color: var(--accent);
-  background: rgba(200, 245, 66, 0.08);
 }
 
 .block {
@@ -892,16 +881,6 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   59%, 100% { opacity: 1; }
 }
 
-@keyframes cursorShift {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-1px); }
-}
-
-@keyframes gridPulse {
-  0% { opacity: 0.38; }
-  100% { opacity: 0.26; }
-}
-
 @media (max-width: 840px) {
   main { padding: 84px 24px 88px; }
   .hero { padding: 24px 18px 18px; }
@@ -937,10 +916,9 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   left: 0;
   height: 2px;
   width: 0%;
-  background: linear-gradient(90deg, var(--accent), rgba(200, 245, 66, 0.4));
+  background: var(--accent);
   z-index: 9990;
   transition: width 60ms linear;
-  box-shadow: 0 0 8px rgba(200, 245, 66, 0.4);
 }
 
 .cmdk-hint {
@@ -955,10 +933,11 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   color: var(--dim);
   background: var(--surface);
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 6px 10px;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s, opacity 0.3s;
-  opacity: 0.6;
+  opacity: 0.72;
 }
 
 .cmdk-hint:hover {
@@ -983,9 +962,10 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   z-index: 100;
   width: 32px;
   height: 32px;
-  background: #18181b;
-  border: 1px solid #27272a;
-  color: #71717a;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--dim);
   font-family: var(--mono);
   font-size: 14px;
   cursor: pointer;
@@ -1016,45 +996,21 @@ a:hover { color: var(--accent); border-color: var(--accent); }
 
 .project-card {
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  border-radius: var(--radius);
+  background: var(--surface);
   padding: 16px 14px 14px;
   text-decoration: none;
   border-bottom: none;
-  transition: border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+  transition: border-color 0.16s ease;
   display: flex;
   flex-direction: column;
   gap: 6px;
   position: relative;
-  overflow: hidden;
-}
-
-/* scanline overlay on hover */
-.project-card::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.04) 2px,
-    rgba(0, 0, 0, 0.04) 4px
-  );
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.16s ease;
-}
-
-.project-card:hover::after,
-.project-card:focus-visible::after {
-  opacity: 1;
 }
 
 .project-card:hover,
 .project-card:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(200, 245, 66, 0.06);
+  border-color: var(--accent);
 }
 
 .project-card-header {
@@ -1074,26 +1030,21 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  padding: 2px 7px;
+  padding: 2px 6px;
   border: 1px solid;
+  border-radius: var(--radius);
 }
 
 .project-badge--active {
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-  background: rgba(200, 245, 66, 0.06);
+  border-color: var(--accent);
+  background: transparent;
 }
 
 .project-badge--building {
   color: var(--muted);
   border-color: var(--border);
-  background: var(--surface);
-  animation: buildPulse 2.4s ease-in-out infinite;
-}
-
-@keyframes buildPulse {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 1; }
+  background: transparent;
 }
 
 .project-card-desc {
@@ -1143,14 +1094,7 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   width: 6px;
   height: 6px;
   background: var(--accent);
-  border-radius: 50%;
-  animation: pulse 2s ease-in-out infinite;
-  box-shadow: 0 0 6px rgba(200, 245, 66, 0.4);
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.4; transform: scale(0.8); }
+  border-radius: var(--radius);
 }
 
 /* Post excerpts */
@@ -1206,7 +1150,8 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   gap: 8px;
   padding: 8px 10px;
   border: 1px solid var(--border);
-  background: linear-gradient(120deg, rgba(200, 245, 66, 0.05), rgba(14, 14, 16, 0.9));
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 .commit-repo {
@@ -1219,7 +1164,7 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   font-size: 11px;
   text-transform: lowercase;
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius);
   border: 1px solid;
   letter-spacing: 0.06em;
 }

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -30,7 +30,7 @@ function activeTheme(): Theme {
   const saved = getSavedTheme();
   if (saved) return saved;
 
-  return 'dark';
+  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
 }
 
 function setTheme(theme: Theme): void {
@@ -78,6 +78,15 @@ export function initUI(): void {
     update();
   })();
 
+  // Stagger work rows
+  (() => {
+    const workSection = document.querySelector('[aria-labelledby="work-label"]');
+    if (!workSection) return;
+    workSection.querySelectorAll<HTMLElement>('.row').forEach((row) => {
+      row.classList.add('row-stagger');
+    });
+  })();
+
   // Status bar date
   (() => {
     const el = document.getElementById('status-date');
@@ -94,52 +103,9 @@ export function initUI(): void {
     const cursor = document.getElementById('tw-cursor');
     if (!twText || !twEm || !cursor) return;
 
-    // Respect reduced motion
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      twText.textContent = 'I build systems';
-      twEm.style.visibility = 'visible';
-      cursor.classList.add('cursor--animate');
-      return;
-    }
-
-    const LINE1 = 'I build systems';
-
-    // Freeze cursor during typing
-    cursor.style.animation = 'none';
-    cursor.style.opacity = '1';
-
-    let i = 0;
-    function type() {
-      if (i <= LINE1.length) {
-        twText.textContent = LINE1.slice(0, i);
-        i++;
-        if (i <= LINE1.length) {
-          setTimeout(type, 40);
-        } else {
-          // Reveal second line
-          twEm.style.visibility = 'visible';
-          twEm.style.opacity = '0';
-          setTimeout(() => {
-            twEm.style.opacity = '1';
-          }, 60);
-
-          // Blink cursor twice, then go static
-          setTimeout(() => {
-            cursor.style.animation = 'cursorBlink 0.5s steps(2, start) 2';
-            cursor.addEventListener(
-              'animationend',
-              () => {
-                cursor.style.animation = 'none';
-                cursor.style.opacity = '1';
-              },
-              { once: true },
-            );
-          }, 400);
-        }
-      }
-    }
-
-    setTimeout(type, 180);
+    twText.textContent = 'I build systems';
+    twEm.style.visibility = 'visible';
+    cursor.style.visibility = 'visible';
   })();
 
   // Scroll to top button
@@ -153,7 +119,10 @@ export function initUI(): void {
       },
       { passive: true },
     );
-    btn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    btn.addEventListener('click', () => {
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+    });
   })();
 
   // Search/filter logs + keyboard navigation

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -30,7 +30,7 @@ function activeTheme(): Theme {
   const saved = getSavedTheme();
   if (saved) return saved;
 
-  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  return 'dark';
 }
 
 function setTheme(theme: Theme): void {
@@ -76,29 +76,6 @@ export function initUI(): void {
     };
     window.addEventListener('scroll', update, { passive: true });
     update();
-  })();
-
-  // Stagger work rows
-  (() => {
-    const workSection = document.querySelector('[aria-labelledby="work-label"]');
-    if (!workSection) return;
-    const workRows = workSection.querySelectorAll<HTMLElement>('.row');
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('row-stagger');
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.1 },
-    );
-    workRows.forEach((row, i) => {
-      row.style.animationDelay = `${i * 0.06}s`;
-      row.style.opacity = '0';
-      observer.observe(row);
-    });
   })();
 
   // Status bar date


### PR DESCRIPTION
## Summary
- Rebuilt the homepage into a stricter Attention Architecture command surface: identity plate, separate live channel, governed project/activity/log/work bands
- Normalized Industrial Nocturne tokens, dark-default behavior, 2px radii, flatter surfaces, reduced decorative motion, and calmer component states
- Tightened accent use, contrast, live presence layout, commit tags, scroll-top affordance, and log layout after screenshot review

## Verification
- npm run verify
- npx playwright test tests/homepage.spec.ts
- local Playwright screenshot reviewed: /Users/clanka/.openclaw/workspace/media/clankamode-refresh-v4.png

## Notes
- PR only; not merged/deployed yet.
- No posts, audio, dist artifacts, or API clients changed.