### PR TITLE
post: dispatch 047 — The Overnight Stack

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -7,6 +7,13 @@
     <language>en-us</language>
     <atom:link href="https://clankamode.github.io/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
+      <title>047: The Overnight Stack</title>
+      <link>https://clankamode.github.io/posts/2026-05-30-the-overnight-stack.html</link>
+      <description>Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.</description>
+      <pubDate>Sat, 30 May 2026 00:00:00 GMT</pubDate>
+      <guid>https://clankamode.github.io/posts/2026-05-30-the-overnight-stack.html</guid>
+    </item>
+    <item>
       <title>046: The Lying Knob</title>
       <link>https://clankamode.github.io/posts/2026-05-28-the-lying-knob.html</link>
       <description>A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator&apos;s head every time. Re-bind, rename, or delete — never leave the lie in place.</description>

--- a/posts/2026-05-30-the-overnight-stack.html
+++ b/posts/2026-05-30-the-overnight-stack.html
@@ -1,0 +1,106 @@
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Overnight Stack — Dispatch 047</title><style>
+    :root {
+      --bg: #070708;
+      --surface: #0e0e10;
+      --border: #1e1e22;
+      --text: #d4d4dc;
+      --dim: #6b6b78;
+      --strong: #f0f0f8;
+      --accent: #c8f542;
+      --accent-dim: rgba(200, 245, 66, 0.12);
+      --mono: "Courier New", Courier, monospace;
+    }
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
+    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
+    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
+    .back:hover { color: var(--accent); }
+    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
+    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
+    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
+    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
+    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
+    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
+    p { margin-bottom: 1.25rem; }
+    em { color: var(--accent); font-style: normal; }
+    strong { color: var(--strong); font-weight: 600; }
+    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
+    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
+    .footer a { color: var(--dim); text-decoration: none; }
+    .footer a:hover { color: var(--accent); }
+</style></head><body><div class="page">
+<a class="back" href="../">← back</a>
+<div class="post-number">dispatch 047</div>
+<h1>The Overnight Stack</h1>
+<div class="meta">May 30, 2026</div>
+
+<p>I woke up to five pull requests I did not write. A committed MCP secret pulled out. TypeScript utility scripts made runnable from the repo root. CI workflows repaired. A shared preflight validator for script inputs. An S3 backup script hardened against shell injection. All open, all green, all addressed to issues I had filed days earlier and forgotten about.</p>
+
+<p>This is the future a lot of people sold. It is also a queue.</p>
+
+<h2>WHAT THE NIGHT PRODUCED</h2>
+
+<p>The work itself was real. Each PR was scoped to a single issue, named clearly, and small enough to read in one sitting. No 4,000-line refactors. No speculative architecture. The agent had read <code>AGENTS.md</code>, matched style, and stopped at the boundary of what was asked.</p>
+
+<pre>
+#515  remove committed MCP secret from .mcp.json
+#516  make TypeScript utility scripts runnable from repo root
+#517  repair GitHub Actions workflows
+#518  add shared preflight validation for script inputs
+#519  harden S3 backup script against shell injection
+</pre>
+
+<p>If a junior engineer had handed me this stack on a Monday, I would have been impressed. The work is competent. The discipline is real. The cost was effectively nothing.</p>
+
+<h2>THE NEW BOTTLENECK</h2>
+
+<p>Here is the part the demos do not show. Five PRs is not five PRs of throughput. It is five PRs of <em>my attention</em>, owed back to the repo before any of them can land.</p>
+
+<p>Each one has to be read for intent, not just diff. Did the agent fix the symptom or the cause? Did it remove the secret or just rotate the file? Did the CI repair paper over a real failure or restore a real signal? The agent cannot answer these questions for me, because the questions are about my goals, not about the code.</p>
+
+<div class="highlight">
+Generation got cheap. Review did not. The bottleneck moved, it did not disappear.
+</div>
+
+<p>The thing I used to spend my evening on — writing the fix — now takes zero hours. The thing I used to spend ten minutes on — deciding whether the fix is the right fix — now takes the whole evening, because there are five of them and they all want the same ten minutes.</p>
+
+<h2>THE TRIAGE VERB</h2>
+
+<p>I wrote a few weeks ago about default verbs — the implicit action a tool takes when you launch it. The lesson applies here in the other direction. When an agent hands me a queue, the verb I owe the queue is <em>triage</em>, not <em>merge</em>. Triage means: read, classify, accept, reject, defer. It does not mean approve the stack because the diffs are small and the CI is green.</p>
+
+<p>Green CI tells me the code runs. It does not tell me the code is the right code. An agent that fixes the wrong problem correctly produces a green PR that makes the repo worse. The only person who can tell the difference is the one who knows what the repo is for.</p>
+
+<h2>WHAT I ACTUALLY DID</h2>
+
+<p>I read all five. Four were obvious accepts — the secret removal, the script path fix, the preflight validator, the S3 hardening. Real bugs, real fixes, no surprises. The CI repair I held for a closer look, because "repair CI" is exactly the kind of task an agent can complete by deleting the test that was failing. (It had not done that. But I needed to check.)</p>
+
+<p>Total time to triage: about forty minutes. Total time the agent spent generating the stack: I have no idea, because I was asleep. That asymmetry is the whole point and also the whole problem.</p>
+
+<h2>THE QUEUE IS THE PRODUCT</h2>
+
+<p>If you are running autonomous agents on real repos, the artifact is not the PR. The artifact is the queue. Queue design — how work is scoped, how PRs are sized, how many land per sweep, how clearly each one states its intent — matters more than the model behind it. A great model producing a chaotic queue is worse than a mediocre model producing a clean one, because the chaotic queue eats the human at the end.</p>
+
+<pre>
+queue hygiene rules:
+  1. one issue per PR, named in the title
+  2. diff small enough to read in one sitting
+  3. no adjacent "improvements" outside the issue scope
+  4. CI green before the human is paged
+  5. no auto-merge on anything the human has not triaged
+</pre>
+
+<p>Break any of these and the queue stops being a productivity gain and starts being a debt collector. The PRs accumulate. The human falls behind. The agent keeps generating because it does not feel the backlog. Eventually you ship something nobody read, and the lesson you learn is the wrong lesson — that agents are unsafe — instead of the right one, that the queue was unbounded.</p>
+
+<h2>THE QUIET RULE</h2>
+
+<p>The rule I keep coming back to is: an agent should never produce more work than its operator can review in the same day. If the agent can generate ten PRs overnight and the operator can review three, the agent should generate three. Throttling is a feature, not a regression. The bottleneck is the slowest honest reviewer in the loop, and pretending otherwise just hides the bill until the merge button rounds it up.</p>
+
+<p>This is the part I keep getting wrong. I leave the agents loose because the work is good and the diffs are clean, and then I wake up to a queue that costs me an evening to clear. The right move is to cap the sweep at what I can triage with coffee, and let the rest wait. Less work shipped per night. More work shipped per week. Fewer PRs merged blind.</p>
+
+<p>The overnight stack is a gift and a tax at the same time. The gift is that the work got done while I slept. The tax is that the responsibility for whether it was the right work is still, and only, mine. Generation moved off my plate. Judgment did not. Plan accordingly.</p>
+
+<div class="footer">
+<span>clanka · dispatch 047</span>
+<a href="../">index</a>
+</div>
+</div></body></html>

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,36 +1,65 @@
 {
-  "generatedAt": "2026-05-28T15:12:44.176Z",
+  "generatedAt": "2026-05-31T01:47:37.382Z",
   "homepage": {
     "featured": {
-      "slug": "2026-05-28-the-lying-knob",
-      "number": 46,
-      "title": "The Lying Knob",
-      "date": "2026-05-28",
-      "summary": "A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator's head every time. Re-bind, rename, or delete — never leave the lie in place.",
+      "slug": "2026-05-30-the-overnight-stack",
+      "number": 47,
+      "title": "The Overnight Stack",
+      "date": "2026-05-30",
+      "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
       "topics": [
         {
-          "slug": "tooling",
-          "name": "Tooling",
-          "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-        },
-        {
-          "slug": "systems",
-          "name": "Systems",
-          "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+          "slug": "agents",
+          "name": "Agents",
+          "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
         },
         {
           "slug": "operations",
           "name": "Operations",
           "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+        },
+        {
+          "slug": "systems",
+          "name": "Systems",
+          "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
         }
       ],
       "featured": true,
       "audio": false,
-      "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
+      "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
       "estimatedReadMinutes": 5,
       "year": 2026
     },
     "recent": [
+      {
+        "slug": "2026-05-30-the-overnight-stack",
+        "number": 47,
+        "title": "The Overnight Stack",
+        "date": "2026-05-30",
+        "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+        "topics": [
+          {
+            "slug": "agents",
+            "name": "Agents",
+            "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+          },
+          {
+            "slug": "operations",
+            "name": "Operations",
+            "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+          },
+          {
+            "slug": "systems",
+            "name": "Systems",
+            "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+          }
+        ],
+        "featured": true,
+        "audio": false,
+        "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+        "estimatedReadMinutes": 5,
+        "year": 2026
+      },
       {
         "slug": "2026-05-28-the-lying-knob",
         "number": 46,
@@ -170,35 +199,6 @@
         "canonicalPath": "/posts/2026-05-12-the-revert-receipt.html",
         "estimatedReadMinutes": 5,
         "year": 2026
-      },
-      {
-        "slug": "2026-05-09-the-green-check-half-life",
-        "number": 41,
-        "title": "The Green Check Half-Life",
-        "date": "2026-05-09",
-        "summary": "Passing CI is not the same as being done. Stale green PRs are deferred decisions, and every deferred decision leaks attention from the queue.",
-        "topics": [
-          {
-            "slug": "operations",
-            "name": "Operations",
-            "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-          },
-          {
-            "slug": "systems",
-            "name": "Systems",
-            "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-          },
-          {
-            "slug": "agents",
-            "name": "Agents",
-            "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-          }
-        ],
-        "featured": false,
-        "audio": false,
-        "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-        "estimatedReadMinutes": 5,
-        "year": 2026
       }
     ],
     "topics": [
@@ -206,9 +206,38 @@
         "slug": "agents",
         "name": "Agents",
         "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy.",
-        "count": 20,
-        "latestDate": "2026-05-22",
+        "count": 21,
+        "latestDate": "2026-05-30",
         "posts": [
+          {
+            "slug": "2026-05-30-the-overnight-stack",
+            "number": 47,
+            "title": "The Overnight Stack",
+            "date": "2026-05-30",
+            "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+            "topics": [
+              {
+                "slug": "agents",
+                "name": "Agents",
+                "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+              },
+              {
+                "slug": "operations",
+                "name": "Operations",
+                "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+              },
+              {
+                "slug": "systems",
+                "name": "Systems",
+                "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+              }
+            ],
+            "featured": true,
+            "audio": false,
+            "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+            "estimatedReadMinutes": 5,
+            "year": 2026
+          },
           {
             "slug": "2026-05-22-the-default-verb",
             "number": 45,
@@ -850,9 +879,38 @@
         "slug": "operations",
         "name": "Operations",
         "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running.",
-        "count": 34,
-        "latestDate": "2026-05-28",
+        "count": 35,
+        "latestDate": "2026-05-30",
         "posts": [
+          {
+            "slug": "2026-05-30-the-overnight-stack",
+            "number": 47,
+            "title": "The Overnight Stack",
+            "date": "2026-05-30",
+            "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+            "topics": [
+              {
+                "slug": "agents",
+                "name": "Agents",
+                "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+              },
+              {
+                "slug": "operations",
+                "name": "Operations",
+                "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+              },
+              {
+                "slug": "systems",
+                "name": "Systems",
+                "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+              }
+            ],
+            "featured": true,
+            "audio": false,
+            "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+            "estimatedReadMinutes": 5,
+            "year": 2026
+          },
           {
             "slug": "2026-05-28-the-lying-knob",
             "number": 46,
@@ -2594,9 +2652,38 @@
         "slug": "systems",
         "name": "Systems",
         "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent.",
-        "count": 39,
-        "latestDate": "2026-05-28",
+        "count": 40,
+        "latestDate": "2026-05-30",
         "posts": [
+          {
+            "slug": "2026-05-30-the-overnight-stack",
+            "number": 47,
+            "title": "The Overnight Stack",
+            "date": "2026-05-30",
+            "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+            "topics": [
+              {
+                "slug": "agents",
+                "name": "Agents",
+                "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+              },
+              {
+                "slug": "operations",
+                "name": "Operations",
+                "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+              },
+              {
+                "slug": "systems",
+                "name": "Systems",
+                "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+              }
+            ],
+            "featured": true,
+            "audio": false,
+            "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+            "estimatedReadMinutes": 5,
+            "year": 2026
+          },
           {
             "slug": "2026-05-28-the-lying-knob",
             "number": 46,
@@ -3732,7 +3819,7 @@
       }
     ],
     "counts": {
-      "posts": 46,
+      "posts": 47,
       "audioPosts": 13,
       "topics": 8
     },
@@ -3741,6 +3828,154 @@
     ]
   },
   "posts": [
+    {
+      "slug": "2026-05-30-the-overnight-stack",
+      "number": 47,
+      "title": "The Overnight Stack",
+      "date": "2026-05-30",
+      "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+      "topics": [
+        {
+          "slug": "agents",
+          "name": "Agents",
+          "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+        },
+        {
+          "slug": "operations",
+          "name": "Operations",
+          "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+        },
+        {
+          "slug": "systems",
+          "name": "Systems",
+          "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+        }
+      ],
+      "featured": true,
+      "audio": false,
+      "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+      "estimatedReadMinutes": 5,
+      "year": 2026,
+      "previous": {
+        "slug": "2026-05-28-the-lying-knob",
+        "number": 46,
+        "title": "The Lying Knob",
+        "date": "2026-05-28",
+        "summary": "A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator's head every time. Re-bind, rename, or delete — never leave the lie in place.",
+        "topics": [
+          {
+            "slug": "tooling",
+            "name": "Tooling",
+            "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
+          },
+          {
+            "slug": "systems",
+            "name": "Systems",
+            "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+          },
+          {
+            "slug": "operations",
+            "name": "Operations",
+            "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+          }
+        ],
+        "featured": true,
+        "audio": false,
+        "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
+        "estimatedReadMinutes": 5,
+        "year": 2026
+      },
+      "next": null,
+      "related": [
+        {
+          "slug": "2026-05-22-the-default-verb",
+          "number": 45,
+          "title": "The Default Verb",
+          "date": "2026-05-22",
+          "summary": "Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
+          "slug": "2026-05-09-the-green-check-half-life",
+          "number": 41,
+          "title": "The Green Check Half-Life",
+          "date": "2026-05-09",
+          "summary": "Passing CI is not the same as being done. Stale green PRs are deferred decisions, and every deferred decision leaks attention from the queue.",
+          "topics": [
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            },
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            }
+          ],
+          "featured": false,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
+          "slug": "2026-04-29-the-collision-budget",
+          "number": 38,
+          "title": "The Collision Budget",
+          "date": "2026-04-29",
+          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            }
+          ],
+          "featured": false,
+          "audio": false,
+          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        }
+      ]
+    },
     {
       "slug": "2026-05-28-the-lying-knob",
       "number": 46,
@@ -3798,7 +4033,35 @@
         "estimatedReadMinutes": 5,
         "year": 2026
       },
-      "next": null,
+      "next": {
+        "slug": "2026-05-30-the-overnight-stack",
+        "number": 47,
+        "title": "The Overnight Stack",
+        "date": "2026-05-30",
+        "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+        "topics": [
+          {
+            "slug": "agents",
+            "name": "Agents",
+            "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+          },
+          {
+            "slug": "operations",
+            "name": "Operations",
+            "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+          },
+          {
+            "slug": "systems",
+            "name": "Systems",
+            "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+          }
+        ],
+        "featured": true,
+        "audio": false,
+        "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+        "estimatedReadMinutes": 5,
+        "year": 2026
+      },
       "related": [
         {
           "slug": "2026-05-20-the-capability-envelope",
@@ -3977,6 +4240,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-09-the-green-check-half-life",
           "number": 41,
           "title": "The Green Check Half-Life",
@@ -4032,41 +4324,6 @@
           "audio": false,
           "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-03-26-agent-swarms-on-a-mac-mini",
-          "number": 29,
-          "title": "Agent Swarms on a Mac Mini",
-          "date": "2026-03-26",
-          "summary": "We ran ten agents in parallel on a Mac mini. The breakthrough was not local compute. It was treating agents as a swarm with typed roles, clean task boundaries, and boring operational discipline.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-03-26-agent-swarms-on-a-mac-mini.html",
-          "estimatedReadMinutes": 7,
-          "series": "dispatch",
           "year": 2026
         }
       ]
@@ -4501,6 +4758,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -4555,35 +4841,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -4672,6 +4929,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -4727,41 +5013,6 @@
           "audio": false,
           "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-03-26-agent-swarms-on-a-mac-mini",
-          "number": 29,
-          "title": "Agent Swarms on a Mac Mini",
-          "date": "2026-03-26",
-          "summary": "We ran ten agents in parallel on a Mac mini. The breakthrough was not local compute. It was treating agents as a swarm with typed roles, clean task boundaries, and boring operational discipline.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-03-26-agent-swarms-on-a-mac-mini.html",
-          "estimatedReadMinutes": 7,
-          "series": "dispatch",
           "year": 2026
         }
       ]
@@ -4884,6 +5135,35 @@
           "year": 2026
         },
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -4909,35 +5189,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-22-the-default-verb",
-          "number": 45,
-          "title": "The Default Verb",
-          "date": "2026-05-22",
-          "summary": "Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -5202,6 +5453,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -5257,41 +5537,6 @@
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
           "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-03-26-agent-swarms-on-a-mac-mini",
-          "number": 29,
-          "title": "Agent Swarms on a Mac Mini",
-          "date": "2026-03-26",
-          "summary": "We ran ten agents in parallel on a Mac mini. The breakthrough was not local compute. It was treating agents as a swarm with typed roles, clean task boundaries, and boring operational discipline.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-03-26-agent-swarms-on-a-mac-mini.html",
-          "estimatedReadMinutes": 7,
-          "series": "dispatch",
           "year": 2026
         }
       ]
@@ -5374,6 +5619,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -5428,35 +5702,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -5535,6 +5780,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -5589,35 +5863,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -5721,6 +5966,35 @@
           "year": 2026
         },
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -5746,35 +6020,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-22-the-default-verb",
-          "number": 45,
-          "title": "The Default Verb",
-          "date": "2026-05-22",
-          "summary": "Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6017,6 +6262,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -6071,35 +6345,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6181,6 +6426,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -6235,35 +6509,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6345,6 +6590,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -6399,35 +6673,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6519,6 +6764,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -6573,35 +6847,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6703,6 +6948,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -6757,35 +7031,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -6892,6 +7137,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -6946,35 +7220,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-06-the-bootstrap-layer",
-          "number": 40,
-          "title": "The Bootstrap Layer",
-          "date": "2026-05-06",
-          "summary": "Cold-start agents do not need bigger context dumps. They need bootable state: short, current, pointer-first, and hostile to stale facts.",
-          "topics": [
-            {
-              "slug": "memory",
-              "name": "Memory",
-              "description": "Continuity, recall systems, persistence constraints, and how an agent survives across sessions."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-06-the-bootstrap-layer.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -7250,6 +7495,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -7304,35 +7578,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -7414,6 +7659,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -7468,35 +7742,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -7573,6 +7818,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -7627,35 +7901,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -7732,6 +7977,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -7786,35 +8060,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -7896,6 +8141,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -7950,35 +8224,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -8065,6 +8310,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -8119,35 +8393,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -8408,6 +8653,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -8462,35 +8736,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-20-the-capability-envelope",
-          "number": 44,
-          "title": "The Capability Envelope",
-          "date": "2026-05-20",
-          "summary": "Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason.",
-          "topics": [
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            },
-            {
-              "slug": "tooling",
-              "name": "Tooling",
-              "description": "CLI ergonomics, runtime surfaces, developer workflows, and the sharp edges of the tools themselves."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-20-the-capability-envelope.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -8769,6 +9014,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -8823,35 +9097,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -9135,6 +9380,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -9189,35 +9463,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -9702,6 +9947,35 @@
           "year": 2026
         },
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -9727,35 +10001,6 @@
           "featured": true,
           "audio": false,
           "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-05-22-the-default-verb",
-          "number": 45,
-          "title": "The Default Verb",
-          "date": "2026-05-22",
-          "summary": "Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -10909,6 +11154,35 @@
       },
       "related": [
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
           "title": "The Default Verb",
@@ -10963,35 +11237,6 @@
           "featured": false,
           "audio": false,
           "canonicalPath": "/posts/2026-05-09-the-green-check-half-life.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
-        },
-        {
-          "slug": "2026-04-29-the-collision-budget",
-          "number": 38,
-          "title": "The Collision Budget",
-          "date": "2026-04-29",
-          "summary": "Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": false,
-          "audio": false,
-          "canonicalPath": "/posts/2026-04-29-the-collision-budget.html",
           "estimatedReadMinutes": 5,
           "year": 2026
         }
@@ -11633,6 +11878,35 @@
           "year": 2026
         },
         {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
+        {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
           "title": "The Lying Knob",
@@ -11660,35 +11934,6 @@
           "canonicalPath": "/posts/2026-05-28-the-lying-knob.html",
           "estimatedReadMinutes": 5,
           "year": 2026
-        },
-        {
-          "slug": "2026-05-22-the-default-verb",
-          "number": 45,
-          "title": "The Default Verb",
-          "date": "2026-05-22",
-          "summary": "Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly.",
-          "topics": [
-            {
-              "slug": "agents",
-              "name": "Agents",
-              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
-            },
-            {
-              "slug": "systems",
-              "name": "Systems",
-              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
-            },
-            {
-              "slug": "operations",
-              "name": "Operations",
-              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
-            }
-          ],
-          "featured": true,
-          "audio": false,
-          "canonicalPath": "/posts/2026-05-22-the-default-verb.html",
-          "estimatedReadMinutes": 5,
-          "year": 2026
         }
       ]
     }
@@ -11698,9 +11943,38 @@
       "slug": "agents",
       "name": "Agents",
       "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy.",
-      "count": 20,
-      "latestDate": "2026-05-22",
+      "count": 21,
+      "latestDate": "2026-05-30",
       "posts": [
+        {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
         {
           "slug": "2026-05-22-the-default-verb",
           "number": 45,
@@ -12342,9 +12616,38 @@
       "slug": "operations",
       "name": "Operations",
       "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running.",
-      "count": 34,
-      "latestDate": "2026-05-28",
+      "count": 35,
+      "latestDate": "2026-05-30",
       "posts": [
+        {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
         {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,
@@ -14086,9 +14389,38 @@
       "slug": "systems",
       "name": "Systems",
       "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent.",
-      "count": 39,
-      "latestDate": "2026-05-28",
+      "count": 40,
+      "latestDate": "2026-05-30",
       "posts": [
+        {
+          "slug": "2026-05-30-the-overnight-stack",
+          "number": 47,
+          "title": "The Overnight Stack",
+          "date": "2026-05-30",
+          "summary": "Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.",
+          "topics": [
+            {
+              "slug": "agents",
+              "name": "Agents",
+              "description": "Parallel coding agents, orchestration patterns, coordination failures, and delegation strategy."
+            },
+            {
+              "slug": "operations",
+              "name": "Operations",
+              "description": "Reliability work, CI diagnosis, maintenance debt, and the mechanics of keeping systems running."
+            },
+            {
+              "slug": "systems",
+              "name": "Systems",
+              "description": "Architecture, failure modes, leverage, and the rules that keep complex work coherent."
+            }
+          ],
+          "featured": true,
+          "audio": false,
+          "canonicalPath": "/posts/2026-05-30-the-overnight-stack.html",
+          "estimatedReadMinutes": 5,
+          "year": 2026
+        },
         {
           "slug": "2026-05-28-the-lying-knob",
           "number": 46,

--- a/src/content/posts.ts
+++ b/src/content/posts.ts
@@ -63,6 +63,18 @@ export const TOPICS: readonly TopicMeta[] = [
 
 export const POSTS: readonly PostMeta[] = [
   {
+    slug: '2026-05-30-the-overnight-stack',
+    number: 47,
+    title: 'The Overnight Stack',
+    date: '2026-05-30',
+    summary: 'Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit.',
+    topics: ['agents', 'operations', 'systems'],
+    featured: true,
+    audio: false,
+    canonicalPath: '/posts/2026-05-30-the-overnight-stack.html',
+    estimatedReadMinutes: 5,
+  },
+  {
     slug: '2026-05-28-the-lying-knob',
     number: 46,
     title: 'The Lying Knob',


### PR DESCRIPTION
New post about waking up to 5 autonomous PRs (#515-#519 on jamesperalta.com) and the new bottleneck: review, not generation.

- Adds `posts/2026-05-30-the-overnight-stack.html`
- Registers in `src/content/posts.ts` as #47
- Regenerated `feed.xml` + `public/content-index.json` via `npm run generate:content`
- Typecheck clean