### PR TITLE
perf(audio): stop per-frame getComputedStyle in Listen Mode loop

### DIFF
--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -15,6 +15,15 @@
   let listenMode = false;
   let animFrame;
 
+  // Cache the accent color so the animation loop never has to call
+  // getComputedStyle() per frame. The loop writes --accent-pulse every frame,
+  // so reading computed styles each frame would force a synchronous style
+  // recalc 60×/sec. --accent only changes on theme toggle, so refresh it then.
+  let accentColor = '#c8f542';
+  let themeObserver;
+  const readAccentColor = () =>
+    getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#c8f542';
+
   // --- SVG Icons ---
   const playSvg = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="3,1 13,8 3,15" fill="currentColor"/></svg>`;
   const pauseSvg = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="2" y="1" width="4" height="14" rx="1" fill="currentColor"/><rect x="10" y="1" width="4" height="14" rx="1" fill="currentColor"/></svg>`;
@@ -93,6 +102,9 @@
   function enterListenMode() {
     if (listenMode) return;
     listenMode = true;
+    accentColor = readAccentColor();
+    themeObserver = new MutationObserver(() => { accentColor = readAccentColor(); });
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
     sizeCanvas();
     document.body.classList.add('listen-mode');
     // listen-mode-sync added dynamically when audio reaches first timed paragraph
@@ -102,6 +114,8 @@
   function exitListenMode() {
     if (!listenMode) return;
     listenMode = false;
+    themeObserver?.disconnect();
+    themeObserver = undefined;
     document.body.classList.remove('listen-mode', 'listen-mode-sync');
     cancelAnimationFrame(animFrame);
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -125,7 +139,7 @@
 
       const barCount = analyser.frequencyBinCount;
       const barWidth = w / barCount;
-      const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#c8f542';
+      const accent = accentColor;
 
       for (let i = 0; i < barCount; i++) {
         const v = dataArray[i] / 255;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a deep performance bug in the audio player's "Listen Mode" animation loop (`posts/audio-player.js`).

While a post's narration is playing, `animate()` runs on every `requestAnimationFrame` (~60fps). Each frame it read the static `--accent` color via:

```js
const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#c8f542';
```

This is a classic style-thrash:

- `getComputedStyle()` forces the browser to resolve styles for the element if they're dirty.
- The **same loop** writes an inline style every frame (`document.documentElement.style.setProperty('--accent-pulse', ...)`), which dirties the element's style.
- So every frame did **write → read**, forcing a full synchronous style recalculation 60×/second — for a value that only ever changes when the user toggles the theme.

On long posts with the visualizer running this burns main-thread time continuously during playback and can cause jank.

## Fix

Cache the accent color and refresh it only when the theme actually changes:

- Read `--accent` once in `enterListenMode()`.
- Watch `document.documentElement`'s `data-theme` attribute with a `MutationObserver` (the theme toggle sets `dataset.theme`) to refresh the cached value.
- Disconnect the observer in `exitListenMode()`.
- The loop now reads the cached `accentColor` instead of calling `getComputedStyle()`.

Behavior is unchanged (waveform still uses the correct accent, and it still updates live on theme toggle); only the per-frame forced style recalc is removed.

## Verification

- `npm run typecheck`
- `npm run test:content`
- `npm run build`
- `npm run test` (Playwright e2e, incl. existing `audio-player.spec.ts`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1717-c43e-76b8-8928-859a67eacc88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1717-c43e-76b8-8928-859a67eacc88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

