### PR TITLE
Fix bug-bash round 2: stale-safe sync recovery and live widget retries

### DIFF
--- a/now.html
+++ b/now.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="CLANKA // Now" />
   <meta property="og:description" content="What Clanka is working on right now." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://clankamode.github.io/now" />
+  <meta property="og:url" content="https://clankamode.github.io/now.html" />
+  <link rel="canonical" href="https://clankamode.github.io/now.html" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
@@ -412,7 +413,7 @@
   </section>
 
   <div class="updated">
-    Last updated: <time datetime="2026-02-25">2026-02-25</time>
+    Last updated: <time datetime="2026-07-14">2026-07-14</time>
   </div>
 
   <footer>

--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -130,8 +130,8 @@
     if (!listenMode) return;
     animFrame = requestAnimationFrame(animate);
 
-    // Waveform
-    if (analyser && dataArray) {
+    // Waveform + accent pulse (skip when the user prefers reduced motion)
+    if (!prefersReducedMotion && analyser && dataArray) {
       analyser.getByteFrequencyData(dataArray);
       const w = canvas.width;
       const h = canvas.height;
@@ -149,7 +149,6 @@
       }
       ctx.globalAlpha = 1;
 
-      // Accent breathing
       const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length / 255;
       document.documentElement.style.setProperty('--accent-pulse', `hsl(73, 89%, ${62 + avg * 15}%)`);
     }
@@ -208,12 +207,23 @@
     initAudio();
     if (audio.paused) {
       if (audioCtx && audioCtx.state === 'suspended') audioCtx.resume();
-      audio.play();
-      setPlayState(true);
-      enterListenMode();
+      const playAttempt = audio.play();
+      if (playAttempt && typeof playAttempt.then === 'function') {
+        playAttempt.then(() => {
+          setPlayState(true);
+          enterListenMode();
+        }).catch(() => {
+          setPlayState(false);
+          exitListenMode();
+        });
+      } else {
+        setPlayState(true);
+        enterListenMode();
+      }
     } else {
       audio.pause();
       setPlayState(false);
+      exitListenMode();
     }
   });
 
@@ -223,12 +233,17 @@
   }));
 
   const speeds = [1, 1.25, 1.5, 1.75, 2];
+  const updateSpeedLabel = () => {
+    speedBtn.textContent = speed === 1 ? '1×' : `${speed}×`;
+    speedBtn.setAttribute('aria-label', `Playback speed, ${speed === 1 ? '1×' : `${speed}×`}`);
+  };
   speedBtn.addEventListener('click', () => {
     const idx = (speeds.indexOf(speed) + 1) % speeds.length;
     speed = speeds[idx];
     audio.playbackRate = speed;
-    speedBtn.textContent = speed === 1 ? '1×' : `${speed}×`;
+    updateSpeedLabel();
   });
+  updateSpeedLabel();
 
   function updateProgressAria() {
     if (!audio.duration) return;

--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -107,10 +107,12 @@
   window.addEventListener('scroll', updateBar, { passive: true });
   updateBar();
 
-  // 2. Estimated reading time
-  const content = document.querySelector('.page');
-  if (content) {
-    const words = content.textContent?.split(/\s+/).length || 0;
+  // 2. Estimated reading time (article body only — exclude footer/nav chrome)
+  const readingRoot = document.querySelector('article') || document.querySelector('.page');
+  if (readingRoot) {
+    const clone = readingRoot.cloneNode(true);
+    clone.querySelectorAll('.audio-player, .footer, .post-nav, .post-nav-enhanced, .meta, .post-number, script, style').forEach((el) => el.remove());
+    const words = (clone.textContent || '').trim().split(/\s+/).filter(Boolean).length;
     const mins = Math.max(1, Math.ceil(words / 220));
     const meta = document.querySelector('.meta');
     if (meta && !/\bmin read\b/i.test(meta.textContent || '')) {
@@ -118,14 +120,15 @@
     }
   }
 
-  // 3. Keyboard navigation: j/k for prev/next (resolved at keydown so async
-  //    content-index nav enhancements stay in sync with on-screen links)
+  // 3. Keyboard navigation: j/k for prev/next. Prefer data-nav from content-index
+  //    enhancement; fall back to legacy static nav only after enhance settles.
+  let navEnhanceSettled = false;
   const resolveNavHref = (which) => {
     const nav = document.querySelector('.post-nav-enhanced') || document.querySelector('.post-nav');
     if (!nav) return null;
     const marked = nav.querySelector(`a[data-nav="${which}"]`);
     if (marked) return marked.getAttribute('href');
-    // Fallback for static legacy nav: first link = older/prev, second = newer/next
+    if (!navEnhanceSettled) return null;
     const links = nav.querySelectorAll('a[href]');
     if (which === 'prev') return links[0]?.getAttribute('href') || null;
     return links.length > 1 ? links[1].getAttribute('href') : null;
@@ -153,7 +156,10 @@
     injectStyles();
 
     const slug = window.location.pathname.split('/').pop()?.replace(/\.html$/, '');
-    if (!slug) return;
+    if (!slug) {
+      navEnhanceSettled = true;
+      return;
+    }
 
     try {
       const response = await fetch(CONTENT_INDEX_URL, {
@@ -254,6 +260,8 @@
       }
     } catch {
       // Best-effort enhancement only.
+    } finally {
+      navEnhanceSettled = true;
     }
   })();
 })();

--- a/src/clanka-activity.ts
+++ b/src/clanka-activity.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchEvents, relativeTime } from './time-utils';
+import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
 
@@ -10,6 +11,7 @@ export class ClankaActivity extends LitElement {
   @state() private loading = true;
   @state() private error = '';
   private viewportObserver?: IntersectionObserver;
+  private loadInFlight = false;
 
   static styles = css`
     :host { display: block; margin-bottom: 64px; }
@@ -79,8 +81,11 @@ export class ClankaActivity extends LitElement {
   }
 
   private async loadData(): Promise<void> {
+    if (this.loadInFlight) return;
+    this.loadInFlight = true;
+
     try {
-      const result = await fetchEvents();
+      const result = await withResultRetries(() => fetchEvents());
       if (!result.ok) {
         this.error = '[ activity unavailable ]';
         this.events = [];
@@ -90,6 +95,7 @@ export class ClankaActivity extends LitElement {
       }
     } finally {
       this.loading = false;
+      this.loadInFlight = false;
     }
   }
 

--- a/src/clanka-commits.ts
+++ b/src/clanka-commits.ts
@@ -1,4 +1,5 @@
 import { fetchGithubEvents, type GithubEvent } from './clanka-api';
+import { withResultRetries } from './retry';
 
 const COMMIT_TYPES = ['feat', 'fix', 'chore', 'docs', 'test', 'refactor', 'ci', 'build', 'style'] as const;
 
@@ -57,7 +58,7 @@ export async function loadCommitFeed(): Promise<void> {
   commitFeedLoadInFlight = true;
 
   try {
-    const result = await fetchGithubEvents();
+    const result = await withResultRetries(() => fetchGithubEvents());
 
     if (!result.ok) {
       setFeedText('// activity unavailable');

--- a/src/clanka-fleet.ts
+++ b/src/clanka-fleet.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchFleetSummary } from './clanka-api';
+import { withRetries } from './retry';
 
 type Tier = 'ops' | 'infra' | 'core' | 'quality' | 'policy' | 'template';
 type Criticality = 'critical' | 'high' | 'medium';
@@ -260,16 +261,12 @@ export class ClankaFleet extends LitElement {
     this.error = '';
 
     try {
-      const data = await fetchFleetSummary();
+      const data = await withRetries(() => fetchFleetSummary());
       const repos = this.extractRepos(data);
-      if (!repos.length) {
-        this.repos = [];
-        this.live = false;
-        this.error = '[ fleet registry empty ]';
-        return;
-      }
       this.repos = repos;
+      // Valid empty registry is still a successful sync — not offline.
       this.live = true;
+      this.error = repos.length ? '' : '[ fleet registry empty ]';
     } catch {
       this.repos = [];
       this.live = false;
@@ -283,6 +280,7 @@ export class ClankaFleet extends LitElement {
   private get syncLabel(): string {
     if (this.loading) return 'SYNCING';
     if (!this.live) return 'OFFLINE';
+    if (!this.repos.length) return 'SYNCED';
     return this.repos.some((repo) => repo.online !== null) ? 'LIVE' : 'SYNCED';
   }
 

--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -8,6 +8,7 @@ export class ClankaPresence extends LitElement {
   @state() private status: string = 'OPERATIONAL';
   @state() private loading = true;
   @state() private error = '';
+  @state() private stale = false;
   private pollId?: number;
   private hasSyncedOnce = false;
   private updateInFlight = false;
@@ -142,15 +143,25 @@ export class ClankaPresence extends LitElement {
         this.status = 'operational';
       }
       this.error = '';
+      this.stale = false;
       this.hasSyncedOnce = true;
       this.dispatchEvent(new CustomEvent('sync-updated', { detail: data }));
     } catch {
       if (!this.isConnected) return;
 
-      this.error = '[ api unreachable ]';
-      this.current = '[ offline ]';
-      this.status = 'offline';
-      this.dispatchEvent(new CustomEvent('sync-error', { detail: { error: this.error } }));
+      if (!this.hasSyncedOnce) {
+        this.error = '[ api unreachable ]';
+        this.current = '[ offline ]';
+        this.status = 'offline';
+        this.stale = false;
+      } else {
+        // Keep last-good presence text; mark chrome as stale instead of wiping.
+        this.error = '';
+        this.stale = true;
+      }
+      this.dispatchEvent(new CustomEvent('sync-error', {
+        detail: { error: '[ api unreachable ]', hadSync: this.hasSyncedOnce },
+      }));
     } finally {
       this.updateInFlight = false;
       if (this.isConnected) {
@@ -163,13 +174,18 @@ export class ClankaPresence extends LitElement {
     const normalizedStatus = this.status.toLowerCase();
     const showThinking = normalizedStatus === 'thinking';
     const showOffline = normalizedStatus === 'offline';
+    const statusLabel = this.loading
+      ? 'SYNCING'
+      : this.stale
+        ? 'STALE'
+        : this.status.toUpperCase();
 
     return html`
       <div class="hd">
         <span class="hd-name">CLANKA ⚡</span>
         <span class="hd-status">
-          <span class="dot ${showThinking ? 'thinking' : ''}" style=${showOffline ? 'opacity:.4' : ''}></span>
-          ${this.loading ? 'SYNCING' : this.status.toUpperCase()}
+          <span class="dot ${showThinking ? 'thinking' : ''}" style=${showOffline || this.stale ? 'opacity:.4' : ''}></span>
+          ${statusLabel}
         </span>
       </div>
       <div class="presence-block">
@@ -178,7 +194,7 @@ export class ClankaPresence extends LitElement {
           ? html`<span class="loading"> [ loading... ]</span><div class="skeleton" aria-hidden="true"></div>`
           : this.error
             ? html`<span class="error"> ${this.error}</span>`
-            : html` ${this.current}`}
+            : html` ${this.current}${this.stale ? html`<span class="error"> [ reconnecting… ]</span>` : ''}`}
       </div>
     `;
   }

--- a/src/clanka-stats.ts
+++ b/src/clanka-stats.ts
@@ -1,4 +1,5 @@
 import { fetchFleetSummary, fetchGithubStats } from './clanka-api';
+import { withRetries } from './retry';
 
 const SITE_LAUNCH = new Date('2026-02-19T00:00:00Z');
 
@@ -7,10 +8,6 @@ interface GithubStats {
   totalStars: number;
   lastPushedAt: string;
   lastPushedRepo: string;
-}
-
-interface FleetSummary {
-  totalRepos?: number;
 }
 
 const MIN_VALID_PUSHED_AT_MS = Date.parse('2008-01-01T00:00:00Z');
@@ -52,11 +49,38 @@ function setText(id: string, value: string): void {
   if (el) el.textContent = value;
 }
 
+function resolveFleetTotal(data: unknown): number | null {
+  if (!data || typeof data !== 'object') return null;
+
+  const root = data as Record<string, unknown>;
+  const candidates: unknown[] = [root.totalRepos];
+
+  if (root.summary && typeof root.summary === 'object') {
+    candidates.push((root.summary as Record<string, unknown>).totalRepos);
+  }
+
+  if (Array.isArray(root.repos)) candidates.push(root.repos.length);
+  if (Array.isArray(root.fleet)) candidates.push(root.fleet.length);
+
+  if (root.summary && typeof root.summary === 'object') {
+    const summary = root.summary as Record<string, unknown>;
+    if (Array.isArray(summary.repos)) candidates.push(summary.repos.length);
+    if (Array.isArray(summary.fleet)) candidates.push(summary.fleet.length);
+  }
+
+  for (const candidate of candidates) {
+    const total = Number(candidate);
+    if (Number.isFinite(total) && total >= 0) return total;
+  }
+
+  return null;
+}
+
 export async function loadLiveStats(): Promise<void> {
   setText('stat-uptime', `// ${uptimeDays()}d online`);
 
   try {
-    const data = (await fetchGithubStats()) as GithubStats;
+    const data = (await withRetries(() => fetchGithubStats())) as GithubStats;
 
     const repoCount = Number(data.repoCount);
     if (Number.isFinite(repoCount)) {
@@ -79,9 +103,9 @@ export async function loadLiveStats(): Promise<void> {
     }
 
     try {
-      const fleetData = (await fetchFleetSummary()) as FleetSummary;
-      const total = Number(fleetData.totalRepos);
-      if (Number.isFinite(total) && total >= 0) {
+      const fleetData = await withRetries(() => fetchFleetSummary());
+      const total = resolveFleetTotal(fleetData);
+      if (total !== null) {
         setText('stat-fleet-score', `fleet: ${total} repos`);
       } else {
         setText('stat-fleet-score', 'fleet: unavailable');

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchEvents, relativeTime } from './time-utils';
+import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
 
@@ -9,6 +10,7 @@ export class ClankaTerminal extends LitElement {
   @state() private events: EventItem[] = [];
   @state() private loading = true;
   @state() private error = '';
+  private loadInFlight = false;
 
   static styles = css`
     :host {
@@ -57,8 +59,11 @@ export class ClankaTerminal extends LitElement {
   }
 
   private async loadData(): Promise<void> {
+    if (this.loadInFlight) return;
+    this.loadInFlight = true;
+
     try {
-      const result = await fetchEvents();
+      const result = await withResultRetries(() => fetchEvents());
       if (!result.ok) {
         this.error = '[ offline — activity unavailable ]';
         this.events = [];
@@ -71,6 +76,7 @@ export class ClankaTerminal extends LitElement {
       }
     } finally {
       this.loading = false;
+      this.loadInFlight = false;
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,26 +74,43 @@ if (presence) {
     const customEvent = event as CustomEvent<SyncPayload>;
     const data = customEvent.detail || {};
 
-    // Only replace tasks/team when the payload includes those keys. Slim /now
-    // responses (presence-only) must not wipe previously loaded boards.
-    if (tasks && 'tasks' in data) {
-      tasks.tasks = Array.isArray(data.tasks) ? data.tasks : [];
+    // Always clear latched errors on any successful presence sync.
+    if (tasks) {
       tasks.loading = false;
       tasks.error = '';
+      if ('tasks' in data) {
+        tasks.tasks = Array.isArray(data.tasks) ? data.tasks : [];
+      }
     }
-    if (agents && 'team' in data) {
-      agents.team = data.team && typeof data.team === 'object' ? data.team : {};
+    if (agents) {
       agents.loading = false;
       agents.error = '';
+      if ('team' in data) {
+        agents.team = data.team && typeof data.team === 'object' ? data.team : {};
+      }
     }
 
     const activeAgents = resolveActiveAgents(data);
     if (activeAgents !== null) {
       setText('stat-active-agents', `agents: ${activeAgents} active`);
+    } else {
+      const el = document.getElementById('stat-active-agents');
+      if (el?.textContent === 'agents: offline') {
+        setText('stat-active-agents', 'agents: —');
+      }
     }
   });
 
-  presence.addEventListener('sync-error', () => {
+  presence.addEventListener('sync-error', (event: Event) => {
+    const hadSync = Boolean((event as CustomEvent<{ hadSync?: boolean }>).detail?.hadSync);
+
+    // After a successful sync, keep last-good boards visible through transient blips.
+    if (hadSync) {
+      if (agents) agents.loading = false;
+      if (tasks) tasks.loading = false;
+      return;
+    }
+
     if (agents) {
       agents.loading = false;
       agents.error = '[ api unreachable ]';

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,46 @@
+/** Bounded retry with linear backoff for one-shot live widget loads. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = typeof globalThis.setTimeout === 'function' ? globalThis.setTimeout : setTimeout;
+    timer(resolve, ms);
+  });
+}
+
+export async function withRetries<T>(
+  fn: () => Promise<T>,
+  attempts = 3,
+  baseDelayMs = 200,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts - 1) {
+        await delay(baseDelayMs * (attempt + 1));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export async function withResultRetries<T extends { ok: boolean }>(
+  fn: () => Promise<T>,
+  attempts = 3,
+  baseDelayMs = 200,
+): Promise<T> {
+  let last: T | undefined;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await fn();
+    if (last.ok) return last;
+    if (attempt < attempts - 1) {
+      await delay(baseDelayMs * (attempt + 1));
+    }
+  }
+
+  return last as T;
+}

--- a/tests/audio-player.spec.ts
+++ b/tests/audio-player.spec.ts
@@ -55,6 +55,13 @@ test('play adds listen-mode class to body', async ({ page }) => {
   await expect(page.locator('body')).toHaveClass(/listen-mode/);
 });
 
+test('pause exits listen-mode class on body', async ({ page }) => {
+  await page.click('.ap-play');
+  await expect(page.locator('body')).toHaveClass(/listen-mode/);
+  await page.click('.ap-play');
+  await expect(page.locator('body')).not.toHaveClass(/listen-mode/);
+});
+
 // ── 4. Paragraph sync ─────────────────────────────────────────────────────────
 
 test('paragraph sync — correct element gets lm-active', async ({ page }) => {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -176,6 +176,59 @@ test('partial /now payloads do not wipe tasks or agents', async ({ page }) => {
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 3 active');
 });
 
+test('transient sync-error after a successful sync keeps task boards visible', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'stable',
+        status: 'active',
+        agents_active: 2,
+        team: { alpha: { status: 'active' } },
+        tasks: [{ id: 't1', title: 'Stay visible', status: 'todo' }],
+      }),
+    });
+  });
+
+  await page.reload();
+  await expect(page.locator('clanka-tasks#tasks')).toContainText('Stay visible');
+
+  await page.evaluate(() => {
+    const presence = document.getElementById('presence');
+    presence?.dispatchEvent(
+      new CustomEvent('sync-error', {
+        detail: { error: '[ api unreachable ]', hadSync: true },
+      }),
+    );
+  });
+
+  await expect(page.locator('clanka-tasks#tasks')).toContainText('Stay visible');
+  await expect(page.locator('clanka-tasks#tasks')).not.toContainText('[ api unreachable ]');
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: 2 active');
+});
+
+test('slim sync after offline clears latched agent offline state', async ({ page }) => {
+  await page.route(`${API_BASE}/**`, async (route) => {
+    await route.abort('failed');
+  });
+  await page.reload();
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: offline');
+
+  await page.unroute(`${API_BASE}/**`);
+  await page.evaluate(() => {
+    const presence = document.getElementById('presence');
+    presence?.dispatchEvent(
+      new CustomEvent('sync-updated', {
+        detail: { current: 'recovered', status: 'active' },
+      }),
+    );
+  });
+
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: —');
+  await expect(page.locator('clanka-tasks#tasks')).not.toContainText('[ api unreachable ]');
+});
+
 test('command palette exposes listbox semantics for results', async ({ page }) => {
   await page.keyboard.press('Meta+k');
   const palette = page.locator('clanka-cmdk .palette');

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -222,3 +222,24 @@ test('parseNowPayload rejects invalid shapes and preserves optional fields', asy
     },
   );
 });
+
+test('withRetries eventually succeeds and withResultRetries stops on ok', async () => {
+  const { withRetries, withResultRetries } = await loadTsModule('src/retry.ts');
+
+  let attempts = 0;
+  const value = await withRetries(async () => {
+    attempts += 1;
+    if (attempts < 3) throw new Error('fail');
+    return 'ok';
+  }, 3, 1);
+  assert.equal(value, 'ok');
+  assert.equal(attempts, 3);
+
+  let resultAttempts = 0;
+  const result = await withResultRetries(async () => {
+    resultAttempts += 1;
+    return resultAttempts === 2 ? { ok: true, n: resultAttempts } : { ok: false, n: resultAttempts };
+  }, 3, 1);
+  assert.deepEqual(result, { ok: true, n: 2 });
+  assert.equal(resultAttempts, 2);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Second bug-bash pass focused on recovery honesty after the round-1 merge (#63).

## Fixes
- **Stale-safe presence** — transient `/now` poll failures keep last-good status and show `STALE` / reconnecting instead of wiping to offline
- **Sync-error latching** — after a successful sync, blips no longer replace task/agent boards with `[ api unreachable ]`; any successful `sync-updated` clears latched errors; slim recovery clears stuck `agents: offline`
- **Retries** — fleet, terminal, activity, commit feed, and stats use bounded retry/backoff for one-shot loads
- **Fleet honesty** — empty registry stays `SYNCED`, not `OFFLINE`
- **Stats nesting** — fleet total reads the same nested shapes as the fleet widget
- **Audio** — honor `play()` rejection, exit listen-mode on pause, skip waveform/accent pulse under reduced motion, expose speed in `aria-label`
- **Posts / now** — j/k waits for enhance settle before legacy fallback; reading time excludes chrome; `now.html` canonical/OG URL + date fixed

## Tests
`npm run verify` green — content tests, typecheck, build, 43 Playwright e2e.

- Unit: `withRetries` / `withResultRetries`
- E2E: stale sync-error retention, offline→slim recovery, pause exits listen-mode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

