### PR TITLE
Fix bug-bash round 3: honest status chrome, real 404, and payload tolerance

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#070708" />
+  <meta name="description" content="Page not found — CLANKA" />
+  <meta property="og:title" content="404 — CLANKA" />
+  <meta property="og:description" content="No dispatch at this path." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://clankamode.github.io/404.html" />
+  <link rel="canonical" href="https://clankamode.github.io/404.html" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <title>404 — CLANKA</title>
+  <style>
+    :root {
+      --bg: #070708;
+      --text: #d4d4dc;
+      --dim: #6b6b78;
+      --accent: #c8f542;
+      --border: #1e1e22;
+      --font-mono: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+      --font-display: 'Space Mono', 'IBM Plex Mono', monospace;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(ellipse at top, rgba(200, 245, 66, 0.08), transparent 55%),
+        var(--bg);
+      color: var(--text);
+      font-family: var(--font-mono);
+      padding: 24px;
+    }
+    main {
+      max-width: 28rem;
+      text-align: center;
+    }
+    .kicker {
+      color: var(--accent);
+      letter-spacing: 0.24em;
+      text-transform: uppercase;
+      font-size: 11px;
+      margin-bottom: 16px;
+    }
+    h1 {
+      font-family: var(--font-display);
+      font-size: clamp(2.5rem, 8vw, 4rem);
+      margin: 0 0 12px;
+      letter-spacing: 0.04em;
+    }
+    p {
+      color: var(--dim);
+      line-height: 1.6;
+      margin: 0 0 28px;
+    }
+    nav {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+    a {
+      color: var(--text);
+      text-decoration: none;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 2px;
+      letter-spacing: 0.06em;
+      font-size: 13px;
+    }
+    a:hover { color: var(--accent); border-color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="kicker">// not found</p>
+    <h1>404</h1>
+    <p>No dispatch at this path. The link may be stale, mistyped, or never existed.</p>
+    <nav aria-label="Recovery links">
+      <a href="/">home</a>
+      <a href="/logs/">archive</a>
+      <a href="/now.html">now</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -42,11 +42,11 @@
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
 
-<div id="status-bar" role="banner" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SYNCING</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -317,8 +317,8 @@
 
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
 
-<button type="button" class="cmdk-hint" aria-label="Open command palette" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" aria-label="Open command palette" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 
 <script type="module" src="/src/main.ts"></script>

--- a/logs/index.html
+++ b/logs/index.html
@@ -30,11 +30,11 @@
 </head>
 <body >
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -86,8 +86,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/logs-page.ts"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "predev": "npm run generate:content",
     "dev": "vite",
     "prebuild": "npm run generate:content",
-    "build": "vite build && mkdir -p dist/posts dist/audio && cp -R posts/. dist/posts && cp -R audio/. dist/audio && cp og-image.png og-image.svg feed.xml dist/ && cp dist/index.html dist/404.html",
+    "build": "vite build && mkdir -p dist/posts dist/audio && cp -R posts/. dist/posts && cp -R audio/. dist/audio && cp og-image.png og-image.svg feed.xml dist/",
     "preview": "vite preview",
     "pretest": "npm run generate:content && npm run test:content",
     "test:content": "node --test tests/content-index.test.mjs",

--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -254,6 +254,25 @@
     time.textContent = formatTime(audio.duration);
   });
 
+  audio.addEventListener('error', () => {
+    setPlayState(false);
+    exitListenMode();
+    btn.disabled = true;
+    skips.forEach((s) => { s.disabled = true; });
+    speedBtn.disabled = true;
+    progressWrap.setAttribute('aria-disabled', 'true');
+    progressWrap.removeAttribute('tabindex');
+    time.textContent = 'unavailable';
+    container.setAttribute('data-audio-error', '1');
+    if (!container.querySelector('.ap-error')) {
+      const err = document.createElement('span');
+      err.className = 'ap-error';
+      err.setAttribute('role', 'status');
+      err.textContent = 'audio unavailable';
+      container.append(err);
+    }
+  });
+
   audio.addEventListener('ended', () => {
     setPlayState(false);
     progress.style.width = '0%';

--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -145,7 +145,12 @@
   // 4. Back to top on 't'
   document.addEventListener('keydown', (e) => {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-    if (e.key === 't') window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (e.key === 't') {
+      const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ? 'auto'
+        : 'smooth';
+      window.scrollTo({ top: 0, behavior });
+    }
   });
 
   // 5. Shared metadata-driven archive enhancements

--- a/posts/post-styles.css
+++ b/posts/post-styles.css
@@ -47,6 +47,8 @@
     .ap-skip:hover { border-color: var(--accent); color: var(--accent); }
     .ap-speed { background: none; border: 1px solid var(--border); color: var(--dim); font-size: 11px; font-family: var(--font, 'SF Mono', monospace); padding: 4px 8px; border-radius: 4px; cursor: pointer; flex-shrink: 0; transition: border-color 0.2s, color 0.2s; letter-spacing: 0.02em; }
     .ap-speed:hover { border-color: var(--accent); color: var(--accent); }
+    .ap-error { color: var(--dim); font-size: 11px; letter-spacing: 0.04em; }
+    .audio-player[data-audio-error="1"] { opacity: 0.85; }
     /* Waveform canvas */
     .ap-waveform { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; border-radius: 2px; }
     .ap-progress-wrap { position: relative; }

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-04T23:13:58.119Z",
+  "generatedAt": "2026-07-14T14:08:25.348Z",
   "homepage": {
     "featured": {
       "slug": "2026-06-01-the-red-repair",

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -339,11 +339,11 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 </head>
 <body ${bodyAttrs}>
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -364,8 +364,8 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 ${bodyContent}
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="${scriptPath}"></script>
 </body>

--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -116,37 +116,37 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-/** Accept only well-shaped /now payloads so partial garbage never clears live UI. */
+/** Accept well-shaped /now payloads. Invalid optional fields are stripped, not fatal. */
 export function parseNowPayload(payload: unknown): NowPayload | null {
   if (!isPlainObject(payload)) return null;
 
   const result: NowPayload = {};
 
-  if ('current' in payload) {
-    if (typeof payload.current !== 'string') return null;
+  if ('current' in payload && typeof payload.current === 'string') {
     result.current = payload.current;
   }
-  if ('status' in payload) {
-    if (typeof payload.status !== 'string') return null;
+  if ('status' in payload && typeof payload.status === 'string') {
     result.status = payload.status;
   }
-  if ('history' in payload) {
-    if (!Array.isArray(payload.history)) return null;
+  if ('history' in payload && Array.isArray(payload.history)) {
     result.history = payload.history;
   }
-  if ('team' in payload) {
-    if (!isPlainObject(payload.team)) return null;
+  if ('team' in payload && isPlainObject(payload.team)) {
     result.team = payload.team;
   }
-  if ('tasks' in payload) {
-    if (!Array.isArray(payload.tasks)) return null;
+  if ('tasks' in payload && Array.isArray(payload.tasks)) {
     result.tasks = payload.tasks;
   }
   if ('agents_active' in payload) {
-    if (typeof payload.agents_active !== 'number' || !Number.isFinite(payload.agents_active)) {
-      return null;
+    const raw = payload.agents_active;
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+      result.agents_active = Math.floor(raw);
+    } else if (typeof raw === 'string' && raw.trim() !== '') {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed) && parsed >= 0) {
+        result.agents_active = Math.floor(parsed);
+      }
     }
-    result.agents_active = payload.agents_active;
   }
 
   // Require at least one recognizable field so empty objects don't count as success.

--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -359,13 +359,20 @@ export class ClankaCmdk extends LitElement {
         return;
       }
       this.activeIndex = Math.min(this.activeIndex + 1, items.length - 1);
+      this.scrollActiveIntoView();
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       this.activeIndex = Math.max(this.activeIndex - 1, 0);
+      this.scrollActiveIntoView();
     } else if (e.key === 'Enter' && items[this.activeIndex]) {
       e.preventDefault();
       this.navigate(items[this.activeIndex]);
     }
+  }
+
+  private scrollActiveIntoView(): void {
+    const option = this.shadowRoot?.getElementById(`cmdk-option-${this.activeIndex}`);
+    option?.scrollIntoView({ block: 'nearest' });
   }
 
   private highlightMatch(text: string): unknown {
@@ -395,10 +402,10 @@ export class ClankaCmdk extends LitElement {
     const result: unknown[] = [];
     let flatIdx = 0;
     for (const [section, sectionItems] of grouped) {
-      result.push(html`<div class="section-label">${section}</div>`);
-      for (const item of sectionItems) {
+      const groupId = `cmdk-group-${section}`;
+      const options = sectionItems.map((item) => {
         const idx = flatIdx++;
-        result.push(html`
+        return html`
           <div
             id="cmdk-option-${idx}"
             class="item ${idx === this.activeIndex ? 'active' : ''}"
@@ -410,8 +417,15 @@ export class ClankaCmdk extends LitElement {
             <span class="item-label">${this.highlightMatch(item.label)}</span>
             <span class="item-hint">${item.hint}</span>
           </div>
-        `);
-      }
+        `;
+      });
+
+      result.push(html`
+        <div role="group" aria-labelledby=${groupId}>
+          <div class="section-label" id=${groupId}>${section}</div>
+          ${options}
+        </div>
+      `);
     }
     return result;
   }

--- a/src/content-index.ts
+++ b/src/content-index.ts
@@ -74,6 +74,16 @@ function isContentIndex(value: unknown): value is ContentIndex {
   if (!value || typeof value !== 'object') return false;
 
   const candidate = value as Partial<ContentIndex>;
+  const counts = candidate.homepage?.counts;
+  const countsOk =
+    !!counts &&
+    typeof counts.posts === 'number' &&
+    Number.isFinite(counts.posts) &&
+    typeof counts.audioPosts === 'number' &&
+    Number.isFinite(counts.audioPosts) &&
+    typeof counts.topics === 'number' &&
+    Number.isFinite(counts.topics);
+
   return (
     typeof candidate.generatedAt === 'string' &&
     Array.isArray(candidate.posts) &&
@@ -82,7 +92,7 @@ function isContentIndex(value: unknown): value is ContentIndex {
     !!candidate.homepage &&
     Array.isArray(candidate.homepage.recent) &&
     Array.isArray(candidate.homepage.topics) &&
-    !!candidate.homepage.counts &&
+    countsOk &&
     Array.isArray(candidate.homepage.years)
   );
 }

--- a/src/homepage-content.ts
+++ b/src/homepage-content.ts
@@ -30,6 +30,10 @@ export async function renderHomepageContent(): Promise<void> {
   } catch {
     showArchiveUnavailable(featuredHost);
     showArchiveUnavailable(previewHost);
+    if (topicsHost) topicsHost.textContent = '';
+    if (postsCount) postsCount.textContent = 'archive unavailable';
+    if (audioCount) audioCount.textContent = 'audio unavailable';
+    if (archiveCta) archiveCta.textContent = 'archive unavailable';
     return;
   }
 

--- a/src/lazy-near-viewport.ts
+++ b/src/lazy-near-viewport.ts
@@ -24,6 +24,8 @@ export function runWhenNearViewport(
 
   const nearEnough = (): boolean => {
     const r = el.getBoundingClientRect();
+    // Zero-size targets are often not laid out yet — treat as "not near" and
+    // keep observing / retrying rather than permanently skipping.
     if (r.height <= 0 && r.width <= 0) return false;
     const vh = window.innerHeight;
     return r.top < vh + prefetchPx && r.bottom > -prefetchPx;
@@ -39,15 +41,36 @@ export function runWhenNearViewport(
     return noop;
   }
 
+  let resizeObserver: ResizeObserver | undefined;
+  const runOnce = (): void => {
+    observer.disconnect();
+    resizeObserver?.disconnect();
+    fn();
+  };
+
   const observer = new IntersectionObserver(
     (entries) => {
       if (!entries.some((e) => e.isIntersecting)) return;
-      observer.disconnect();
-      fn();
+      runOnce();
     },
     { root: null, rootMargin: `0px 0px ${prefetchPx}px 0px`, threshold: 0 },
   );
   observer.observe(el);
 
-  return () => observer.disconnect();
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      if (nearEnough()) runOnce();
+    });
+    resizeObserver.observe(el);
+  }
+
+  // Retry once after layout for initially zero-size targets.
+  window.requestAnimationFrame(() => {
+    if (nearEnough()) runOnce();
+  });
+
+  return () => {
+    observer.disconnect();
+    resizeObserver?.disconnect();
+  };
 }

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -101,13 +101,53 @@ export function initUI(): void {
     });
   })();
 
-  // Status bar date
+  // Status bar date + live/site honesty
   (() => {
     const el = document.getElementById('status-date');
-    if (!el) return;
-    const d = new Date();
-    const pad = (n: number) => String(n).padStart(2, '0');
-    el.textContent = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    if (el) {
+      const d = new Date();
+      const pad = (n: number) => String(n).padStart(2, '0');
+      el.textContent = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    }
+
+    const liveLabel = document.getElementById('status-live-label');
+    const liveDot = document.getElementById('status-live-dot') as HTMLElement | null;
+    if (!liveLabel) return;
+
+    const setLiveState = (label: string, offline: boolean): void => {
+      liveLabel.textContent = label;
+      if (liveDot) {
+        liveDot.style.opacity = offline ? '0.35' : '';
+      }
+    };
+
+    const presence = document.getElementById('presence');
+    if (!presence) {
+      // Archive/topic shells have no telemetry presence widget.
+      if (liveLabel.textContent === 'SYNCING' || liveLabel.textContent === 'LIVE') {
+        setLiveState('SITE', false);
+      }
+      return;
+    }
+
+    presence.addEventListener('sync-updated', () => {
+      setLiveState('LIVE', false);
+    });
+    presence.addEventListener('sync-error', () => {
+      setLiveState('OFFLINE', true);
+    });
+  })();
+
+  // Platform-aware command palette hint (⌘K vs Ctrl+K)
+  (() => {
+    const hintKeys = document.querySelectorAll('.cmdk-hint-keys');
+    if (!hintKeys.length) return;
+    const isApple = /Mac|iPhone|iPad|iPod/i.test(navigator.platform || '')
+      || /Mac OS X/i.test(navigator.userAgent || '');
+    const label = isApple ? '⌘K' : 'Ctrl+K';
+    hintKeys.forEach((el) => {
+      el.textContent = label;
+    });
   })();
 
   // Typewriter hero

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -143,3 +143,18 @@ test('post j/k keyboard navigation follows enhanced prev/next links', async ({ p
   await page.keyboard.press('k');
   await expect(page).toHaveURL(prevHref!);
 });
+
+test('404 page is a dedicated not-found shell', async ({ page }) => {
+  await page.goto('/404.html');
+  await expect(page.locator('h1')).toHaveText('404');
+  await expect(page.locator('main')).toContainText('No dispatch at this path');
+  await expect(page.locator('body')).not.toContainText('I build systems');
+  await expect(page.getByRole('link', { name: 'home' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'archive' })).toBeVisible();
+});
+
+test('archive status bar does not claim LIVE telemetry', async ({ page }) => {
+  await page.goto('/logs/');
+  await page.waitForSelector('#archive-search-input');
+  await expect(page.locator('#status-live-label')).toHaveText('SITE');
+});

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -133,6 +133,7 @@ test('live widgets show offline state when API is unreachable', async ({ page })
   await page.waitForSelector('#stat-active-agents');
 
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: offline');
+  await expect(page.locator('#status-live-label')).toHaveText('OFFLINE');
   await expect(page.locator('clanka-agents#agents')).toContainText('[ api unreachable ]');
   await expect(page.locator('clanka-tasks#tasks')).toContainText('[ api unreachable ]');
   await expect(page.locator('clanka-terminal#terminal')).toContainText('[ offline — activity unavailable ]');

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -198,6 +198,22 @@ test('parseNowPayload rejects invalid shapes and preserves optional fields', asy
   assert.equal(parseNowPayload({ tasks: 'nope' }), null);
   assert.equal(parseNowPayload({ team: [] }), null);
 
+  // Malformed optional fields are stripped; good fields still apply.
+  assert.deepEqual(
+    parseNowPayload({
+      current: 'building',
+      status: 'active',
+      agents_active: '7',
+      history: 'bad',
+      team: 'nope',
+    }),
+    {
+      current: 'building',
+      status: 'active',
+      agents_active: 7,
+    },
+  );
+
   assert.deepEqual(parseNowPayload({ current: 'building', status: 'active' }), {
     current: 'building',
     status: 'active',

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -129,6 +129,7 @@ test('homepage logs section links into archive and renders generated topic chips
 
 test('active agent stat is populated from live now payload', async ({ page }) => {
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 7 active');
+  await expect(page.locator('#status-live-label')).toHaveText('LIVE');
 });
 
 test('homepage repo stats are populated from mocked API responses', async ({ page }) => {
@@ -143,4 +144,17 @@ test('homepage commit feed renders recent GitHub activity', async ({ page }) => 
   await expect(commitFeed.locator('.commit-repo')).toHaveText('site');
   await expect(commitFeed.locator('.commit-tag')).toHaveText('feat');
   await expect(commitFeed).not.toContainText('// no activity data');
+});
+
+test('homepage archive stats show unavailable when content-index fails', async ({ page }) => {
+  await page.route('**/content-index.json', async (route) => {
+    await route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' });
+  });
+
+  await page.reload();
+  await page.locator('.logs-section').scrollIntoViewIfNeeded();
+  await expect(page.locator('#homepage-featured-log')).toContainText('archive unavailable');
+  await expect(page.locator('#stat-posts')).toHaveText('archive unavailable');
+  await expect(page.locator('#stat-audio-posts')).toHaveText('audio unavailable');
+  await expect(page.locator('#logs-archive-link-count')).toHaveText('archive unavailable');
 });

--- a/topics/agents/index.html
+++ b/topics/agents/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="agents">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/identity/index.html
+++ b/topics/identity/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="identity">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/memory/index.html
+++ b/topics/memory/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="memory">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/operations/index.html
+++ b/topics/operations/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="operations">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/philosophy/index.html
+++ b/topics/philosophy/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="philosophy">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/systems/index.html
+++ b/topics/systems/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="systems">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/teaching/index.html
+++ b/topics/teaching/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="teaching">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/topics/tooling/index.html
+++ b/topics/tooling/index.html
@@ -30,11 +30,11 @@
 </head>
 <body data-topic-slug="tooling">
 <a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="status-bar" aria-hidden="true">
-  <span id="status-left">CLANKA // ONLINE · ⚡ clankamode.github.io · <span id="status-date"></span></span>
+<div id="status-bar" role="status" aria-live="polite">
+  <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot"></span>
-    LIVE
+    <span class="status-live-dot" id="status-live-dot"></span>
+    <span id="status-live-label">SITE</span>
   </span>
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
@@ -75,8 +75,8 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true}));" aria-label="Open command palette">
-  <kbd>⌘K</kbd> navigate
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+  <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>
 </body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       input: {
         main: path.resolve(rootDir, 'index.html'),
         now: path.resolve(rootDir, 'now.html'),
+        notFound: path.resolve(rootDir, '404.html'),
         logs: path.resolve(rootDir, 'logs/index.html'),
         ...topicInputs(),
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Third bug-bash pass (independent of open #64). Focuses on user-facing honesty and hard edges that round 1 missed.

## Fixes
- **Real 404** — dedicated `404.html` instead of cloning the homepage into Pages’ not-found response
- **Status chrome honesty** — homepage status bar tracks presence (`LIVE` / `OFFLINE` / `SYNCING`); archive/topic shells show `SITE` instead of a fake `LIVE`
- **`parseNowPayload` tolerance** — malformed optional fields are stripped; numeric string `agents_active` coerced; good fields still apply
- **Homepage index failure** — archive stats/CTA no longer stick on `... posts` placeholders
- **cmdk** — section groups use `role="group"`; active option scrolls into view
- **lazy-near-viewport** — zero-size targets retry via rAF/ResizeObserver instead of being permanently skipped
- **Audio** — load/decode errors disable controls and show `audio unavailable`
- **Misc** — ⌘K/Ctrl+K hint by platform; post `t` respects reduced motion; content-index count validation

## Tests
`npm run verify` green — 43 Playwright e2e.

- Unit: optional-field tolerance for `/now`
- E2E: 404 shell, LIVE/OFFLINE/SITE status labels, homepage archive unavailable path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

