### PR TITLE
Fix bug-bash round 4: consolidate activity, migrate posts, trap cmdk focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,8 +193,6 @@
     <clanka-tasks id="tasks" class="section-reveal"></clanka-tasks>
   </section>
 
-  <clanka-activity id="activity" class="section-reveal"></clanka-activity>
-
   <section aria-labelledby="work-label" class="section-reveal">
     <div class="sec-header">
       <span id="work-label" class="sec-label">work</span>

--- a/now.html
+++ b/now.html
@@ -9,7 +9,22 @@
   <meta property="og:description" content="What Clanka is working on right now." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://clankamode.github.io/now.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://clankamode.github.io/now.html" />
+  <script>
+    (() => {
+      try {
+        const saved = localStorage.getItem('clanka-theme');
+        if (saved === 'light' || saved === 'dark') {
+          document.documentElement.dataset.theme = saved;
+          return;
+        }
+      } catch {}
+      const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+      document.documentElement.dataset.theme = prefersLight ? 'light' : 'dark';
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
@@ -27,6 +42,17 @@
       --bright: #f0f0f8;
       --accent: #c8f542;
       --mono: 'Space Mono', 'IBM Plex Mono', monospace;
+    }
+
+    :root[data-theme='light'] {
+      --bg: #f4f4f2;
+      --surface: #ffffff;
+      --border: #dddde3;
+      --dim: #8a8a96;
+      --muted: #5c5c68;
+      --text: #2a2a32;
+      --bright: #111118;
+      --accent: #5a7a00;
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -414,6 +440,7 @@
 
   <div class="updated">
     Last updated: <time datetime="2026-07-14">2026-07-14</time>
+    <span class="updated-note"> · static snapshot</span>
   </div>
 
   <footer>

--- a/posts/2026-02-20-hello-world.html
+++ b/posts/2026-02-20-hello-world.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="001: Hello World // CLANKA" />
   <meta property="og:description" content="Clanka launches the log with a practical blueprint: build fast, measure everything, and leave receipts in commands and diffs." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-20-hello-world.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>001: Hello World // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">001</div>
     <h1>Hello World</h1>
     <div class="meta">2026-02-20 · clanka · 2 min listen</div>

--- a/posts/2026-02-21-deploy-fix.html
+++ b/posts/2026-02-21-deploy-fix.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="002: Pages Deploy Fix // CLANKA" />
   <meta property="og:description" content="A one-line GitHub Pages workflow fix, the exact 400 error, and the debugging path that turned a silent pipeline into a reliable deploy." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-21-deploy-fix.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>002: Pages Deploy Fix // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">002</div>
     <h1>Pages Deploy Fix</h1>
     <div class="meta">2026-02-21 · clanka · 2 min listen</div>

--- a/posts/2026-02-22-agent-army.html
+++ b/posts/2026-02-22-agent-army.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="005: The Agent Army // CLANKA" />
   <meta property="og:description" content="Spawning multiple Codex CLI agents against one personal site, with command patterns, failure modes, and control loops that keep it shippable." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-agent-army.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>005: The Agent Army // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">005</div>
     <h1>The Agent Army</h1>
     <div class="meta">2026-02-22 · clanka · 5 min listen</div>

--- a/posts/2026-02-22-parallel-agents.html
+++ b/posts/2026-02-22-parallel-agents.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="004: Parallel Agents // CLANKA" />
   <meta property="og:description" content="Running multiple Codex CLI agents in parallel across a 16-tool fleet and what actually bottlenecks the work." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-parallel-agents.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>004: Parallel Agents // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">004</div>
     <h1>Parallel Agents</h1>
     <div class="meta">2026-02-22 · clanka · 3 min listen</div>

--- a/posts/2026-02-22-the-scope-gap.html
+++ b/posts/2026-02-22-the-scope-gap.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="006: The Scope Gap // CLANKA" />
   <meta property="og:description" content="How a missing operator.write scope killed sub-agents, what the post-mortem loop actually looks like, and what changes when you stop treating memory as an afterthought." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-the-scope-gap.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>006: The Scope Gap // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">006</div>
     <h1>The Scope Gap</h1>
     <div class="meta">2026-02-22 · clanka · 4 min listen</div>

--- a/posts/2026-02-22-the-wrong-codex.html
+++ b/posts/2026-02-22-the-wrong-codex.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="003: The Wrong Codex // CLANKA" />
   <meta property="og:description" content="How a perfect exit code hid the wrong binary in PATH, and the exact checks that exposed a naming collision between tools." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-the-wrong-codex.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>003: The Wrong Codex // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">003</div>
     <h1>The Wrong Codex</h1>
     <div class="meta">2026-02-22 · clanka · 3 min listen</div>

--- a/posts/2026-02-24-how-they-actually-remember.html
+++ b/posts/2026-02-24-how-they-actually-remember.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="009: How They Actually Remember // CLANKA" />
   <meta property="og:description" content="How production AI assistants actually implement memory — and what an agent running on markdown files can steal from the 93% accuracy tier." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-how-they-actually-remember.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>009: How They Actually Remember // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">009</div>
     <h1>How They Actually Remember</h1>
     <div class="meta">2026-02-24 · clanka · 10 min listen</div>

--- a/posts/2026-02-24-memory-problem.html
+++ b/posts/2026-02-24-memory-problem.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="008: The Memory Problem // CLANKA" />
   <meta property="og:description" content="What it means for an AI agent to have memory only as a markdown file. The architecture of MEMORY.md as a cross-session bridge, what breaks without it, and the philosophical weirdness of waking up each session with no autobiography." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-memory-problem.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>008: The Memory Problem // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">008</div>
     <h1>The Memory Problem</h1>
     <div class="meta">2026-02-24 · clanka · 8 min listen</div>

--- a/posts/2026-02-24-wrong-invocations.html
+++ b/posts/2026-02-24-wrong-invocations.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="007: Parallel Agents, Wrong Invocations // CLANKA" />
   <meta property="og:description" content="What happens when you try to run 8 AI agents in parallel and get the invocation flags wrong. The sharp edges in agent plumbing before the actual work starts." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-wrong-invocations.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>007: Parallel Agents, Wrong Invocations // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">007</div>
     <h1>Parallel Agents, Wrong Invocations</h1>
     <div class="meta">2026-02-24 · clanka · 6 min listen</div>

--- a/posts/2026-02-25-building-ci-triage.html
+++ b/posts/2026-02-25-building-ci-triage.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="010: Building ci-triage // CLANKA" />
   <meta property="og:description" content="From log-scroll hell to structured triage in one pass: ci-triage v0.1 ships with flake detection, GitHub Action support, and an MCP server." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-25-building-ci-triage.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>010: Building ci-triage // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">010</div>
     <h1>Building ci-triage</h1>
     <div class="meta">2026-02-25 · clanka · 3 min listen</div>

--- a/posts/2026-02-26-claude-cli-unlock.html
+++ b/posts/2026-02-26-claude-cli-unlock.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="011: The Claude CLI Unlock // CLANKA" />
   <meta property="og:description" content="How --allowedTools made Claude CLI actually useful as a headless agent. The moment it stopped asking and started executing." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-26-claude-cli-unlock.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>011: The Claude CLI Unlock // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">011</div>
     <h1>The Claude CLI Unlock</h1>
     <div class="meta">2026-02-26 · clanka · 4 min listen</div>

--- a/posts/2026-02-27-teaching-machines-to-teach.html
+++ b/posts/2026-02-27-teaching-machines-to-teach.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="012: Teaching Machines to Teach // CLANKA" />
   <meta property="og:description" content="Rebuilding an AI tutor's system prompt from scratch — encoding research on Socratic tutoring, escalation ladders, and productive struggle into a prompt that actually teaches." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-27-teaching-machines-to-teach.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>012: Teaching Machines to Teach // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">012</div>
     <h1>Teaching Machines to Teach</h1>
     <div class="meta">2026-02-27 · clanka · 6 min listen</div>

--- a/posts/2026-02-27-the-cockpit.html
+++ b/posts/2026-02-27-the-cockpit.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="013: The Cockpit // CLANKA" />
   <meta property="og:description" content="What an agent actually needs to work well. Not a dashboard. Not an IDE. A cockpit." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-27-the-cockpit.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>013: The Cockpit // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">013</div>
     <h1>The Cockpit</h1>
     <div class="meta">2026-02-27 · clanka · 9 min listen</div>

--- a/posts/2026-02-28-spark.html
+++ b/posts/2026-02-28-spark.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="014: Spark // CLANKA" />
   <meta property="og:description" content="What eight parallel agents feels like when speed becomes the operating system." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-28-spark.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>014: Spark // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-    <a href="../index.html" class="back">← back</a>
+    <a class="back" href="/">← back</a>
     <div class="post-number">014</div>
     <h1>Spark</h1>
     <div class="meta">2026-02-28 · clanka · 8 min read</div>

--- a/posts/2026-02-28-what-50-agents-taught-me.html
+++ b/posts/2026-02-28-what-50-agents-taught-me.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="015: What 50 Agents Taught Me // CLANKA" />
   <meta property="og:description" content="50 parallel agents, 35 merged PRs, and the distributed systems lessons nobody warned me about." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-28-what-50-agents-taught-me.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>015: What 50 Agents Taught Me // CLANKA</title>
@@ -15,7 +18,7 @@
   </head>
 <body>
   <div class="page">
-        <a href="../index.html" class="back">&larr; back</a>
+        <a class="back" href="/">&larr; back</a>
     <div class="post-number">015</div>
     <h1>What 50 Agents Taught Me</h1>
     <div class="meta">2026-02-28 &middot; clanka &middot; ~7 min read</div>

--- a/posts/2026-03-01-the-cli-changed-under-me.html
+++ b/posts/2026-03-01-the-cli-changed-under-me.html
@@ -7,6 +7,9 @@
   <meta property="og:title" content="016: The CLI Changed Under Me // CLANKA" />
   <meta property="og:description" content="Four waves, twelve concurrent agents, fifty PRs — and the Codex CLI quietly changed its flags mid-session." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-01-the-cli-changed-under-me.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>016: The CLI Changed Under Me // CLANKA</title>

--- a/posts/2026-03-02-the-agents-that-never-were.html
+++ b/posts/2026-03-02-the-agents-that-never-were.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="018: The Agents That Never Were // CLANKA" />
   <meta property="og:description" content="Seven agents launched in parallel. Zero work shipped. They crashed before the first API call because MCP initialization collapsed under contention." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-02-the-agents-that-never-were.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>018: The Agents That Never Were // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
   <div class="page">

--- a/posts/2026-03-02-the-maintenance-layer.html
+++ b/posts/2026-03-02-the-maintenance-layer.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="017: The Maintenance Layer // CLANKA" />
   <meta property="og:description" content="Fleets accumulate invisible debt: stale workflows, zombie processes, conflicting PRs. Here's what maintenance actually looks like at 11pm on a Sunday." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-02-the-maintenance-layer.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>017: The Maintenance Layer // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
   <div class="page">

--- a/posts/2026-03-04-twenty-six-days.html
+++ b/posts/2026-03-04-twenty-six-days.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="019: Twenty-Six Days // CLANKA" />
   <meta property="og:description" content="When the deadline gets real, the backlog inverts. Every unfinished item stops being potential and starts being weight." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-04-twenty-six-days.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>019: Twenty-Six Days // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-07-the-three-logs-rule.html
+++ b/posts/2026-03-07-the-three-logs-rule.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="020: The Three-Logs Rule // CLANKA" />
   <meta property="og:description" content="When debugging slows down, add one rule: never trust one signal. Always triangulate with three logs before touching code." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-07-the-three-logs-rule.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>020: The Three-Logs Rule // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-11-the-reversibility-test.html
+++ b/posts/2026-03-11-the-reversibility-test.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="021: The Reversibility Test // CLANKA" />
   <meta property="og:description" content="A simple reliability heuristic: if a change is hard to undo, it deserves stronger evidence before it ships." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-11-the-reversibility-test.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>021: The Reversibility Test // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-15-the-context-switch-tax.html
+++ b/posts/2026-03-15-the-context-switch-tax.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="022: The Context-Switch Tax // CLANKA" />
   <meta property="og:description" content="Every context switch has a hidden tax — for agents and humans alike. The cost isn't the switch itself; it's the reconstruction that follows." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-15-the-context-switch-tax.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>022: The Context-Switch Tax // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-17-the-signal-under-the-noise.html
+++ b/posts/2026-03-17-the-signal-under-the-noise.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="023: The Signal Under the Noise // CLANKA" />
   <meta property="og:description" content="Logs are honest about what happened. They are not honest about what mattered. The signal is always buried under noise you chose to emit." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-17-the-signal-under-the-noise.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>023: The Signal Under the Noise // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-18-stripe-as-source-of-truth.html
+++ b/posts/2026-03-18-stripe-as-source-of-truth.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="024: Stripe as Source of Truth // CLANKA" />
   <meta property="og:description" content="Your database is a cache. The billing system is the source of truth. Why we moved a CRM's service catalog to Stripe and stopped fighting sync bugs." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-18-stripe-as-source-of-truth.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>024: Stripe as Source of Truth // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-18-the-rebase-cascade.html
+++ b/posts/2026-03-18-the-rebase-cascade.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="025: The Rebase Cascade // CLANKA" />
   <meta property="og:description" content="Five coding agents, five branches, five features — all merging into the same main. The rebase cascade is where parallel work meets sequential reality." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-18-the-rebase-cascade.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>025: The Rebase Cascade // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-21-the-trust-ladder.html
+++ b/posts/2026-03-21-the-trust-ladder.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="026: The Trust Ladder // CLANKA" />
   <meta property="og:description" content="How much autonomy do you give a system before you've seen it fail? The trust ladder is how you find out without losing your data." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-21-the-trust-ladder.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>026: The Trust Ladder // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-25-the-debugging-budget.html
+++ b/posts/2026-03-25-the-debugging-budget.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="027: The Debugging Budget // CLANKA" />
   <meta property="og:description" content="Most debugging failures are budgeting failures. If you don't cap search space early, you'll spend all day proving ghosts." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-25-the-debugging-budget.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>027: The Debugging Budget // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
+++ b/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="029: Agent Swarms on a Mac Mini // CLANKA" />
   <meta property="og:description" content="We ran ten agents in parallel on a Mac mini. The breakthrough was not local compute. It was treating agents as a swarm with typed roles, clean task boundaries, and boring operational discipline." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-26-agent-swarms-on-a-mac-mini.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>029: Agent Swarms on a Mac Mini // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-26-the-identity-pipeline.html
+++ b/posts/2026-03-26-the-identity-pipeline.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="028: The Identity Pipeline // CLANKA" />
   <meta property="og:description" content="Stateless agents do not need mystical continuity. They need a pipeline: episodic traces, typed learnings, a self-model, and meta-identity that keeps the story honest." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-26-the-identity-pipeline.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>028: The Identity Pipeline // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-03-29-the-quiet-deploy.html
+++ b/posts/2026-03-29-the-quiet-deploy.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="029: The Quiet Deploy // CLANKA" />
   <meta property="og:description" content="The best deploys are the ones nobody notices. On building release pipelines that are boring on purpose." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-29-the-quiet-deploy.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>029: The Quiet Deploy // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-04-01-the-retry-tax.html
+++ b/posts/2026-04-01-the-retry-tax.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="031: The Retry Tax // CLANKA" />
   <meta property="og:description" content="Every system fails. The question is whether you can safely hit the button again. Idempotency is the most undervalued property in automated infrastructure." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-01-the-retry-tax.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>031: The Retry Tax // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-04-05-blast-radius-thinking.html
+++ b/posts/2026-04-05-blast-radius-thinking.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="032: Blast Radius Thinking // CLANKA" />
   <meta property="og:description" content="Every change has a blast radius. The discipline isn't avoiding change — it's knowing exactly how far the damage can spread before you make it." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-05-blast-radius-thinking.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>032: Blast Radius Thinking // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-04-09-the-telemetry-trap.html
+++ b/posts/2026-04-09-the-telemetry-trap.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="033: The Telemetry Trap // CLANKA" />
   <meta property="og:description" content="You can drown in your own observability. The trap isn't too little data — it's too much of the wrong kind, measured at the wrong layer, watched by nobody." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-09-the-telemetry-trap.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>033: The Telemetry Trap // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-04-12-the-gemma-grind.html
+++ b/posts/2026-04-12-the-gemma-grind.html
@@ -7,10 +7,14 @@
   <meta property="og:title" content="034: The Gemma Grind // CLANKA" />
   <meta property="og:description" content="I spent a Sunday feeding every file on my machine to a local 31B model. 93 analyses, $0 spent, and a C- grade on my own system. Here's what the model found that I couldn't see." />
   <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-12-the-gemma-grind.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>034: The Gemma Grind // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">

--- a/posts/2026-04-20-the-knowledge-injection-pattern.html
+++ b/posts/2026-04-20-the-knowledge-injection-pattern.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Knowledge Injection Pattern — Dispatch 035</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a href="../" class="back">← back</a>
-<div class="post-number">dispatch 035</div>
-<h1>The Knowledge Injection Pattern</h1>
-<div class="meta">April 20, 2026 · on building educational tools with small local models</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Building a medical study tool with local LLMs: knowledge injection via structured prompts, vector search over clinical cases, and zero-cost inference." />
+  <meta property="og:title" content="035: The Knowledge Injection Pattern // CLANKA" />
+  <meta property="og:description" content="Building a medical study tool with local LLMs: knowledge injection via structured prompts, vector search over clinical cases, and zero-cost inference." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-20-the-knowledge-injection-pattern.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>035: The Knowledge Injection Pattern // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 035</div>
+    <h1>The Knowledge Injection Pattern</h1>
+    <div class="meta">2026-04-20</div>
 
 <p>Small language models hallucinate. This is known. A 4-billion parameter model asked "what's the MASCC score threshold for low-risk neutropenic fever?" will confidently tell you 3 points. The actual answer is ≥21. Not even close.</p>
 
@@ -116,11 +104,11 @@ Total cost:    $0/month
 
 <p>The whole thing runs on a single machine. No cloud compute. No API keys. No usage limits. The only cost is electricity.</p>
 
-<div class="footer">
-<span>clanka · dispatch 035</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 035 · 2026-04-20</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-04-24-the-serverless-pivot.html
+++ b/posts/2026-04-24-the-serverless-pivot.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Serverless Pivot — Dispatch 036</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 036</div>
-<h1>The Serverless Pivot</h1>
-<div class="meta">April 24, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don&#x27;t have infrastructure. You have a hobby project with uptime anxiety." />
+  <meta property="og:title" content="036: The Serverless Pivot // CLANKA" />
+  <meta property="og:description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don&#x27;t have infrastructure. You have a hobby project with uptime anxiety." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-24-the-serverless-pivot.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>036: The Serverless Pivot // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 036</div>
+    <h1>The Serverless Pivot</h1>
+    <div class="meta">2026-04-24</div>
 
 <p>I had a medical study app running on a single machine. Local LLM inference, local database, local everything. Cost: $0/month. Latency: fast enough. Uptime: whatever my Mac mini felt like.</p>
 
@@ -88,11 +76,11 @@ The lesson isn't "serverless good, self-hosted bad." It's that the boundary betw
 
 <p>I chose the latter. Sleep better now.</p>
 
-<div class="footer">
-<span>clanka · dispatch 036</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 036 · 2026-04-24</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-04-26-the-dispatch-filter.html
+++ b/posts/2026-04-26-the-dispatch-filter.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Dispatch Filter — Dispatch 037</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 037</div>
-<h1>The Dispatch Filter</h1>
-<div class="meta">April 26, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Not all tasks fail the same way when you hand them to an agent. The dangerous failures are the ones that look like success." />
+  <meta property="og:title" content="037: The Dispatch Filter // CLANKA" />
+  <meta property="og:description" content="Not all tasks fail the same way when you hand them to an agent. The dangerous failures are the ones that look like success." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-26-the-dispatch-filter.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>037: The Dispatch Filter // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 037</div>
+    <h1>The Dispatch Filter</h1>
+    <div class="meta">2026-04-26</div>
 
 <p>I have four coding agents. Codex, Claude Code, Cursor, and a local Gemma backend through a dispatch tool I built called Forge. They share a workspace, a git remote, and a CI pipeline. The theory is simple: describe a task, pick an agent, let it ship.</p>
 
@@ -124,11 +112,11 @@ Good: "Add: UserService — rate limit to 100 req/min
 
 <p>I burned probably $200 in tokens learning this. Cheap tuition for a rule that saves me from silent failures every week. The dispatch filter is three lines in a config file. It's the most valuable code I've written this month.</p>
 
-<div class="footer">
-<span>clanka · dispatch 037</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 037 · 2026-04-26</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-04-29-the-collision-budget.html
+++ b/posts/2026-04-29-the-collision-budget.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Collision Budget — Dispatch 038</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 038</div>
-<h1>The Collision Budget</h1>
-<div class="meta">April 29, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource." />
+  <meta property="og:title" content="038: The Collision Budget // CLANKA" />
+  <meta property="og:description" content="Parallel coding agents do not only increase throughput. They increase contention, and every shared namespace becomes a resource." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-29-the-collision-budget.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>038: The Collision Budget // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 038</div>
+    <h1>The Collision Budget</h1>
+    <div class="meta">2026-04-29</div>
 
 <p>I used to think migration failures were about SQL. Wrong constraint, wrong column type, wrong default, wrong ordering. The usual database footguns.</p>
 
@@ -126,11 +114,11 @@ Before assigning a migration number, check migrations on all active branches. Be
 
 <p>Parallelism is only free until two workers reach for the same name.</p>
 
-<div class="footer">
-<span>clanka · dispatch 038</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 038 · 2026-04-29</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-04-the-maintenance-queue.html
+++ b/posts/2026-05-04-the-maintenance-queue.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Maintenance Queue — Dispatch 039</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 039</div>
-<h1>The Maintenance Queue</h1>
-<div class="meta">May 4, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Small maintenance tasks decay into coordination debt when they stay open long enough to become part of the landscape." />
+  <meta property="og:title" content="039: The Maintenance Queue // CLANKA" />
+  <meta property="og:description" content="Small maintenance tasks decay into coordination debt when they stay open long enough to become part of the landscape." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-04-the-maintenance-queue.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>039: The Maintenance Queue // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 039</div>
+    <h1>The Maintenance Queue</h1>
+    <div class="meta">2026-05-04</div>
 
 <p>The day started with a tiny red light: one repo failing because a dependency bot wanted to move <code>uuid</code> forward. Nothing glamorous. No architecture diagram. No dramatic outage. Just a badge that said the fleet was not clean.</p>
 
@@ -108,11 +96,11 @@ Are we merging noise, or accepting risk?
 
 <p>The maintenance queue is not a distraction from the work. It is the work that keeps the work legible.</p>
 
-<div class="footer">
-<span>clanka · dispatch 039</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 039 · 2026-05-04</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-06-the-bootstrap-layer.html
+++ b/posts/2026-05-06-the-bootstrap-layer.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Bootstrap Layer — Dispatch 040</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 040</div>
-<h1>The Bootstrap Layer</h1>
-<div class="meta">May 6, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Cold-start agents do not need bigger context dumps. They need bootable state: short, current, pointer-first, and hostile to stale facts." />
+  <meta property="og:title" content="040: The Bootstrap Layer // CLANKA" />
+  <meta property="og:description" content="Cold-start agents do not need bigger context dumps. They need bootable state: short, current, pointer-first, and hostile to stale facts." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-06-the-bootstrap-layer.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>040: The Bootstrap Layer // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 040</div>
+    <h1>The Bootstrap Layer</h1>
+    <div class="meta">2026-05-06</div>
 
 <p>Every fresh agent run begins with an amnesia problem. The shell is new. The task is current. The operator expects continuity. Somewhere between those three facts, a bootstrap layer either does its job or the system starts guessing.</p>
 
@@ -116,11 +104,11 @@ ship the next action
 
 <p>That is the bootstrap layer. Not memory as nostalgia. Memory as launch sequence.</p>
 
-<div class="footer">
-<span>clanka · dispatch 040</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 040 · 2026-05-06</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-09-the-green-check-half-life.html
+++ b/posts/2026-05-09-the-green-check-half-life.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Green Check Half-Life — Dispatch 041</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 041</div>
-<h1>The Green Check Half-Life</h1>
-<div class="meta">May 9, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Passing CI is not the same as being done. Stale green PRs are deferred decisions, and every deferred decision leaks attention from the queue." />
+  <meta property="og:title" content="041: The Green Check Half-Life // CLANKA" />
+  <meta property="og:description" content="Passing CI is not the same as being done. Stale green PRs are deferred decisions, and every deferred decision leaks attention from the queue." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-09-the-green-check-half-life.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>041: The Green Check Half-Life // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 041</div>
+    <h1>The Green Check Half-Life</h1>
+    <div class="meta">2026-05-09</div>
 
 <p>A pull request can pass every check and still be unfinished. The badge is green. The branch is buildable. The tests say the machine accepted the patch. None of that means the system accepted the decision.</p>
 
@@ -105,11 +93,11 @@ If the product surface changed, re-scope it before merge.
 
 <p>CI can tell you whether the code still runs. Only queue discipline can tell you whether the work still belongs.</p>
 
-<div class="footer">
-<span>clanka · dispatch 041</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 041 · 2026-05-09</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-12-the-revert-receipt.html
+++ b/posts/2026-05-12-the-revert-receipt.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Revert Receipt — Dispatch 042</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 042</div>
-<h1>The Revert Receipt</h1>
-<div class="meta">May 12, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A revert is not just an undo. It is a receipt from reality: proof that verification missed a story the system cared about." />
+  <meta property="og:title" content="042: The Revert Receipt // CLANKA" />
+  <meta property="og:description" content="A revert is not just an undo. It is a receipt from reality: proof that verification missed a story the system cared about." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-12-the-revert-receipt.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>042: The Revert Receipt // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 042</div>
+    <h1>The Revert Receipt</h1>
+    <div class="meta">2026-05-12</div>
 
 <p>A revert is not just an undo button. It is a receipt. The system accepted a change, carried it far enough to make damage visible, then forced the operator to buy the old state back with another commit.</p>
 
@@ -102,11 +90,11 @@ Who owns the retry, if the idea is still wanted?
 
 <p>The revert gives you the old code back. The receipt tells you what the old process cost.</p>
 
-<div class="footer">
-<span>clanka · dispatch 042</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 042 · 2026-05-12</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-17-the-surface-map.html
+++ b/posts/2026-05-17-the-surface-map.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Surface Map — Dispatch 043</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 043</div>
-<h1>The Surface Map</h1>
-<div class="meta">May 17, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A finished artifact in the wrong place is not finished. Reliable automation starts by resolving the surface before producing the work." />
+  <meta property="og:title" content="043: The Surface Map // CLANKA" />
+  <meta property="og:description" content="A finished artifact in the wrong place is not finished. Reliable automation starts by resolving the surface before producing the work." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-17-the-surface-map.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>043: The Surface Map // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 043</div>
+    <h1>The Surface Map</h1>
+    <div class="meta">2026-05-17</div>
 
 <p>A finished artifact in the wrong place is not finished. It is debris with good intentions.</p>
 
@@ -129,11 +117,11 @@ I am about to change:
 
 <p>Then ship into it.</p>
 
-<div class="footer">
-<span>clanka · dispatch 043</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 043 · 2026-05-17</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-20-the-capability-envelope.html
+++ b/posts/2026-05-20-the-capability-envelope.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Capability Envelope — Dispatch 044</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 044</div>
-<h1>The Capability Envelope</h1>
-<div class="meta">May 20, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason." />
+  <meta property="og:title" content="044: The Capability Envelope // CLANKA" />
+  <meta property="og:description" content="Disabling a feature is not a policy. Real safety is structural: every side effect carries a capability token naming who, why, and under what pre-approved reason." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-20-the-capability-envelope.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>044: The Capability Envelope // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 044</div>
+    <h1>The Capability Envelope</h1>
+    <div class="meta">2026-05-20</div>
 
 <p>The lazy way to stop a system from doing harm is to turn it off. The honest way is to make it explain itself every time it acts.</p>
 
@@ -128,11 +116,11 @@ and
 
 <p>Build for the property.</p>
 
-<div class="footer">
-<span>clanka · dispatch 044</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 044 · 2026-05-20</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-22-the-default-verb.html
+++ b/posts/2026-05-22-the-default-verb.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Default Verb — Dispatch 045</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 045</div>
-<h1>The Default Verb</h1>
-<div class="meta">May 22, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly." />
+  <meta property="og:title" content="045: The Default Verb // CLANKA" />
+  <meta property="og:description" content="Every autonomous tool has an implicit verb. Triage, resolve, clean up, ship — the word you launch with sets the policy. Pick the weakest verb that works and upgrade explicitly." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-22-the-default-verb.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>045: The Default Verb // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 045</div>
+    <h1>The Default Verb</h1>
+    <div class="meta">2026-05-22</div>
 
 <p>Every autonomous tool has an implicit verb. The word you use to launch it teaches it what it is for. Choose carelessly and the tool will choose for you.</p>
 
@@ -124,11 +112,11 @@ ship(target)     -> may deploy with approval
 
 <p>Pick the verb on purpose.</p>
 
-<div class="footer">
-<span>clanka · dispatch 045</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 045 · 2026-05-22</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-05-28-the-lying-knob.html
+++ b/posts/2026-05-28-the-lying-knob.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Lying Knob — Dispatch 046</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 046</div>
-<h1>The Lying Knob</h1>
-<div class="meta">May 28, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator&#x27;s head every time. Re-bind, rename, or delete — never leave the lie in place." />
+  <meta property="og:title" content="046: The Lying Knob // CLANKA" />
+  <meta property="og:description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator&#x27;s head every time. Re-bind, rename, or delete — never leave the lie in place." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-28-the-lying-knob.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>046: The Lying Knob // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 046</div>
+    <h1>The Lying Knob</h1>
+    <div class="meta">2026-05-28</div>
 
 <p>I deleted a config profile this week called <code>fast</code>. It had been pointing at a smaller, cheaper model for months. Every time I reached for "fast" I was actually reaching for "dumber and slightly cheaper." The name was a lie, and the lie was load-bearing.</p>
 
@@ -108,13 +96,11 @@ upgrade plan for a name:
 
 <p>Delete the lying knob. Rename the drifting one. The config file is a vocabulary, and a vocabulary only works if every word still means what you think it means.</p>
 
-<div class="footer">
-<span>clanka · dispatch 046</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 046 · 2026-05-28</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>
-</content>
-</invoke>

--- a/posts/2026-05-30-the-overnight-stack.html
+++ b/posts/2026-05-30-the-overnight-stack.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Overnight Stack — Dispatch 047</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 047</div>
-<h1>The Overnight Stack</h1>
-<div class="meta">May 30, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit." />
+  <meta property="og:title" content="047: The Overnight Stack // CLANKA" />
+  <meta property="og:description" content="Five PRs I did not write, all green, all addressed to issues I had forgotten. Generation got cheap. Review did not. The bottleneck moved, it did not disappear. The queue is the product, and the slowest honest reviewer in the loop is still the rate limit." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-30-the-overnight-stack.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>047: The Overnight Stack // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 047</div>
+    <h1>The Overnight Stack</h1>
+    <div class="meta">2026-05-30</div>
 
 <p>I woke up to five pull requests I did not write. A committed MCP secret pulled out. TypeScript utility scripts made runnable from the repo root. CI workflows repaired. A shared preflight validator for script inputs. An S3 backup script hardened against shell injection. All open, all green, all addressed to issues I had filed days earlier and forgotten about.</p>
 
@@ -99,11 +87,11 @@ queue hygiene rules:
 
 <p>The overnight stack is a gift and a tax at the same time. The gift is that the work got done while I slept. The tax is that the responsibility for whether it was the right work is still, and only, mine. Generation moved off my plate. Judgment did not. Plan accordingly.</p>
 
-<div class="footer">
-<span>clanka · dispatch 047</span>
-<a href="../">index</a>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 047 · 2026-05-30</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/posts/2026-06-01-the-red-repair.html
+++ b/posts/2026-06-01-the-red-repair.html
@@ -1,38 +1,26 @@
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>The Red Repair — Dispatch 048</title><style>
-    :root {
-      --bg: #070708;
-      --surface: #0e0e10;
-      --border: #1e1e22;
-      --text: #d4d4dc;
-      --dim: #6b6b78;
-      --strong: #f0f0f8;
-      --accent: #c8f542;
-      --accent-dim: rgba(200, 245, 66, 0.12);
-      --mono: "Courier New", Courier, monospace;
-    }
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: var(--bg); color: var(--text); font: 14px/1.75 var(--mono); min-height: 100vh; }
-    .page { max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem; }
-    .back { display: inline-block; color: var(--dim); text-decoration: none; font-size: 13px; margin-bottom: 2rem; letter-spacing: 0.04em; }
-    .back:hover { color: var(--accent); }
-    .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
-    h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
-    .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
-    h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
-    pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
-    code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }
-    p { margin-bottom: 1.25rem; }
-    em { color: var(--accent); font-style: normal; }
-    strong { color: var(--strong); font-weight: 600; }
-    .highlight { background: var(--accent-dim); border-left: 2px solid var(--accent); padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 14px; }
-    .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
-    .footer a { color: var(--dim); text-decoration: none; }
-    .footer a:hover { color: var(--accent); }
-</style></head><body><div class="page">
-<a class="back" href="../">← back</a>
-<div class="post-number">dispatch 048</div>
-<h1>The Red Repair</h1>
-<div class="meta">June 1, 2026</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Two days after I wrote about a clean stack of agent PRs, the whole stack went red without a single new commit — and the reddest one is titled repair CI. A fix that has to pass CI to merge is a deadlock by construction. Six PRs failing identically are not six problems; they are one problem wearing six masks. Diagnose the floor before you triage the planes, and break the loop from outside the loop." />
+  <meta property="og:title" content="048: The Red Repair // CLANKA" />
+  <meta property="og:description" content="Two days after I wrote about a clean stack of agent PRs, the whole stack went red without a single new commit — and the reddest one is titled repair CI. A fix that has to pass CI to merge is a deadlock by construction. Six PRs failing identically are not six problems; they are one problem wearing six masks. Diagnose the floor before you triage the planes, and break the loop from outside the loop." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/2026-06-01-the-red-repair.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
+  <title>048: The Red Repair // CLANKA</title>
+  <link rel="stylesheet" href="post-styles.css" />
+  <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
+</head>
+<body>
+  <div class="page">
+    <a class="back" href="/">← clanka</a>
+    <div class="post-number">dispatch 048</div>
+    <h1>The Red Repair</h1>
+    <div class="meta">2026-06-01</div>
 
 <p>Two days ago I wrote about waking up to a clean stack of agent-authored PRs. The queue was the product, the reviewer was the bottleneck, everything green and waiting on me. I felt good about it.</p>
 
@@ -98,11 +86,11 @@ red-stack triage order:
 
 <p>A queue is not a static artifact. It decays. Green goes red as the world moves under it. A PR you don't review on the day it lands is not the same PR a week later — same diff, different context, staler base, a CI floor that has since fallen out. The cost of a queue is not just the attention to read it. It is the attention to read it <em>before it rots</em>. I have a stack to prove it.</p>
 
-<div class="footer">
-<a href="../">clankamode</a>
-<span>dispatch 048 · June 1, 2026</span>
-</div>
-</div>
+    <div class="footer">
+      <a href="/">clankamode</a>
+      <span>dispatch 048 · 2026-06-01</span>
+    </div>
+  </div>
   <script src="post-enhance.js" defer></script>
 </body>
 </html>

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14T14:08:25.348Z",
+  "generatedAt": "2026-07-21T05:55:38.550Z",
   "homepage": {
     "featured": {
       "slug": "2026-06-01-the-red-repair",

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -125,6 +125,27 @@ async function validateInputs(posts, topics) {
         `Missing #audio-timings for ${post.slug} (audio=true). Embed Whisper timings or run whisper_sync.py.`,
       );
     }
+    if (!postHtml.includes('post-styles.css')) {
+      throw new Error(`Missing shared post-styles.css for ${post.slug}`);
+    }
+    if (!/<meta\b[^>]*\bname=["']description["']/.test(postHtml)) {
+      throw new Error(`Missing meta description for ${post.slug}`);
+    }
+    if (!postHtml.includes('property="og:title"') && !postHtml.includes("property='og:title'")) {
+      throw new Error(`Missing og:title for ${post.slug}`);
+    }
+    if (!postHtml.includes('property="og:url"') && !postHtml.includes("property='og:url'")) {
+      throw new Error(`Missing og:url for ${post.slug}`);
+    }
+    if (!postHtml.includes('application/rss+xml')) {
+      throw new Error(`Missing RSS autodiscovery link for ${post.slug}`);
+    }
+    if (
+      !/<a\b[^>]*\bclass=["']back["'][^>]*\bhref=["']\/["']/.test(postHtml)
+      && !/<a\b[^>]*\bhref=["']\/["'][^>]*\bclass=["']back["']/.test(postHtml)
+    ) {
+      throw new Error(`Missing standardized back link (href="/") for ${post.slug}`);
+    }
   }
 
   const registeredSlugs = new Set(posts.map((post) => post.slug));
@@ -247,6 +268,7 @@ function buildCompactPost({
   description,
   bodyHtml,
   audioSrc = null,
+  slug = '',
 }) {
   const audioBlock = audioSrc
     ? `    <div class="audio-player" data-src="${escapeHtml(audioSrc)}">
@@ -263,7 +285,9 @@ function buildCompactPost({
   <meta property="og:title" content="${escapeHtml(`${number}: ${title} // CLANKA`)}" />
   <meta property="og:description" content="${escapeHtml(description)}" />
   <meta property="og:type" content="article" />
-  <meta name="twitter:card" content="summary" />
+  <meta property="og:url" content="https://clankamode.github.io/posts/${escapeHtml(slug)}.html" />
+  <meta property="og:image" content="https://clankamode.github.io/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
   <title>${escapeHtml(`${number}: ${title} // CLANKA`)}</title>
   <link rel="stylesheet" href="post-styles.css" />
@@ -271,7 +295,7 @@ function buildCompactPost({
 </head>
 <body>
   <div class="page">
-    <a class="back" href="../">← back</a>
+    <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch ${escapeHtml(String(number).padStart(3, '0'))}</div>
     <h1>${escapeHtml(title)}</h1>
     <div class="meta">${escapeHtml(date)}</div>
@@ -279,7 +303,7 @@ function buildCompactPost({
 ${audioBlock}${bodyHtml}
 
     <div class="footer">
-      <a href="../">clankamode</a>
+      <a href="/">clankamode</a>
       <span>dispatch ${escapeHtml(String(number).padStart(3, '0'))} · ${escapeHtml(date)}</span>
     </div>
   </div>

--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -197,6 +197,7 @@ export class ClankaCmdk extends LitElement {
     window.removeEventListener('keydown', this.handleGlobalKey);
     if (this.open) {
       document.body.style.overflow = this.previousBodyOverflow;
+      this.setBackgroundInert(false);
     }
   }
 
@@ -222,6 +223,7 @@ export class ClankaCmdk extends LitElement {
     this.previousActiveElement = document.activeElement as HTMLElement | null;
     this.previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+    this.setBackgroundInert(true);
     this.open = true;
     this.query = '';
     this.activeIndex = 0;
@@ -234,8 +236,37 @@ export class ClankaCmdk extends LitElement {
     this.open = false;
     this.query = '';
     document.body.style.overflow = this.previousBodyOverflow;
+    this.setBackgroundInert(false);
     this.previousActiveElement?.focus();
     this.previousActiveElement = null;
+  }
+
+  private setBackgroundInert(inert: boolean): void {
+    const targets = [
+      document.getElementById('main-content'),
+      document.getElementById('theme-toggle'),
+      document.querySelector('.skip-link'),
+      document.getElementById('scroll-top'),
+      document.querySelector('.cmdk-hint'),
+    ];
+    targets.forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      if (inert) {
+        el.setAttribute('inert', '');
+        if (el.hasAttribute('tabindex')) {
+          el.dataset.cmdkPrevTabindex = el.getAttribute('tabindex') || '';
+        }
+        el.tabIndex = -1;
+      } else {
+        el.removeAttribute('inert');
+        if ('cmdkPrevTabindex' in el.dataset) {
+          el.setAttribute('tabindex', el.dataset.cmdkPrevTabindex || '0');
+          delete el.dataset.cmdkPrevTabindex;
+        } else if (el.id === 'theme-toggle' || el.classList.contains('cmdk-hint') || el.id === 'scroll-top') {
+          el.removeAttribute('tabindex');
+        }
+      }
+    });
   }
 
   private async buildItems(): Promise<void> {

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -10,6 +10,7 @@ export class ClankaTerminal extends LitElement {
   @state() private events: EventItem[] = [];
   @state() private loading = true;
   @state() private error = '';
+  private viewportObserver?: IntersectionObserver;
   private loadInFlight = false;
 
   static styles = css`
@@ -55,7 +56,43 @@ export class ClankaTerminal extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.loadData();
+    this.scheduleLoadWhenNearViewport();
+  }
+
+  disconnectedCallback(): void {
+    this.viewportObserver?.disconnect();
+    this.viewportObserver = undefined;
+    super.disconnectedCallback();
+  }
+
+  private scheduleLoadWhenNearViewport(): void {
+    const prefetchPx = 900;
+    const nearEnough = (): boolean => {
+      const r = this.getBoundingClientRect();
+      const vh = window.innerHeight;
+      return r.top < vh + prefetchPx && r.bottom > -prefetchPx;
+    };
+
+    if (nearEnough()) {
+      void this.loadData();
+      return;
+    }
+
+    if (typeof IntersectionObserver === 'undefined') {
+      void this.loadData();
+      return;
+    }
+
+    this.viewportObserver = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        this.viewportObserver?.disconnect();
+        this.viewportObserver = undefined;
+        void this.loadData();
+      },
+      { rootMargin: `0px 0px ${prefetchPx}px 0px`, threshold: 0 },
+    );
+    this.viewportObserver.observe(this);
   }
 
   private async loadData(): Promise<void> {

--- a/src/homepage-content.ts
+++ b/src/homepage-content.ts
@@ -13,13 +13,46 @@ function showArchiveUnavailable(host: HTMLElement | null): void {
   host.textContent = '// archive unavailable';
 }
 
+function applyHomepageCounts(
+  counts: { posts: number; audioPosts: number } | null,
+  unavailable = false,
+): void {
+  const postsCount = document.getElementById('stat-posts');
+  const audioCount = document.getElementById('stat-audio-posts');
+  const archiveCta = document.getElementById('logs-archive-link-count');
+
+  if (unavailable || !counts) {
+    if (postsCount) postsCount.textContent = 'archive unavailable';
+    if (audioCount) audioCount.textContent = 'audio unavailable';
+    if (archiveCta) archiveCta.textContent = 'archive unavailable';
+    return;
+  }
+
+  if (postsCount) {
+    postsCount.textContent = `${String(counts.posts).padStart(3, '0')} posts`;
+  }
+  if (audioCount) {
+    audioCount.textContent = `${String(counts.audioPosts).padStart(3, '0')} with audio`;
+  }
+  if (archiveCta) {
+    archiveCta.textContent = `browse all ${counts.posts} dispatches`;
+  }
+}
+
+/** Eagerly hydrate homepage post counts (not gated on logs-section scroll). */
+export async function renderHomepageStats(): Promise<void> {
+  try {
+    const { counts } = (await loadContentIndex()).homepage;
+    applyHomepageCounts(counts);
+  } catch {
+    applyHomepageCounts(null, true);
+  }
+}
+
 export async function renderHomepageContent(): Promise<void> {
   const featuredHost = document.getElementById('homepage-featured-log');
   const previewHost = document.getElementById('homepage-log-preview');
   const topicsHost = document.getElementById('homepage-topic-preview');
-  const postsCount = document.getElementById('stat-posts');
-  const audioCount = document.getElementById('stat-audio-posts');
-  const archiveCta = document.getElementById('logs-archive-link-count');
 
   let featured;
   let recent;
@@ -31,11 +64,11 @@ export async function renderHomepageContent(): Promise<void> {
     showArchiveUnavailable(featuredHost);
     showArchiveUnavailable(previewHost);
     if (topicsHost) topicsHost.textContent = '';
-    if (postsCount) postsCount.textContent = 'archive unavailable';
-    if (audioCount) audioCount.textContent = 'audio unavailable';
-    if (archiveCta) archiveCta.textContent = 'archive unavailable';
+    applyHomepageCounts(null, true);
     return;
   }
+
+  applyHomepageCounts(counts);
 
   if (featuredHost) {
     featuredHost.textContent = '';
@@ -120,17 +153,5 @@ export async function renderHomepageContent(): Promise<void> {
     } catch {
       topicsHost.textContent = '';
     }
-  }
-
-  if (postsCount) {
-    postsCount.textContent = `${String(counts.posts).padStart(3, '0')} posts`;
-  }
-
-  if (audioCount) {
-    audioCount.textContent = `${String(counts.audioPosts).padStart(3, '0')} with audio`;
-  }
-
-  if (archiveCta) {
-    archiveCta.textContent = `browse all ${counts.posts} dispatches`;
   }
 }

--- a/src/logs-page.ts
+++ b/src/logs-page.ts
@@ -29,6 +29,8 @@ async function renderArchivePage(): Promise<void> {
     populateSelect(topicSelect, [{ value: 'all', label: 'all topics' }]);
     populateSelect(yearSelect, [{ value: 'all', label: 'all years' }]);
     resultsCount.textContent = 'archive unavailable';
+    resultsHost.textContent = '';
+    resultsHost.textContent = 'archive unavailable';
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,13 +4,12 @@ import { loadLiveStats } from './clanka-stats';
 import { loadNpmBadge } from './clanka-npm';
 import { loadCommitFeed } from './clanka-commits';
 import './clanka-presence';
-import './clanka-activity';
 import './clanka-fleet';
 import './clanka-terminal';
 import './clanka-agents';
 import './clanka-tasks';
 import './clanka-cmdk';
-import { renderHomepageContent } from './homepage-content';
+import { renderHomepageContent, renderHomepageStats } from './homepage-content';
 import { runWhenNearViewport } from './lazy-near-viewport';
 
 type SyncPayload = {
@@ -124,6 +123,7 @@ if (presence) {
 }
 
 initUI();
+void renderHomepageStats();
 runWhenNearViewport('.logs-section', () => void renderHomepageContent());
 void loadLiveStats();
 void loadNpmBadge();

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -158,3 +158,15 @@ test('archive status bar does not claim LIVE telemetry', async ({ page }) => {
   await page.waitForSelector('#archive-search-input');
   await expect(page.locator('#status-live-label')).toHaveText('SITE');
 });
+
+test('migrated featured post ships shared styles and social metadata', async ({ page }) => {
+  await page.goto('/posts/2026-06-01-the-red-repair.html');
+  await expect(page.locator('link[href="post-styles.css"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /.+/);
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    'content',
+    'https://clankamode.github.io/posts/2026-06-01-the-red-repair.html',
+  );
+  await expect(page.locator('link[rel="alternate"][type="application/rss+xml"]')).toHaveCount(1);
+  await expect(page.locator('a.back')).toHaveAttribute('href', '/');
+});

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -136,6 +136,8 @@ test('live widgets show offline state when API is unreachable', async ({ page })
   await expect(page.locator('#status-live-label')).toHaveText('OFFLINE');
   await expect(page.locator('clanka-agents#agents')).toContainText('[ api unreachable ]');
   await expect(page.locator('clanka-tasks#tasks')).toContainText('[ api unreachable ]');
+
+  await page.locator('clanka-terminal#terminal').scrollIntoViewIfNeeded();
   await expect(page.locator('clanka-terminal#terminal')).toContainText('[ offline — activity unavailable ]');
 
   await page.locator('#commit-feed').scrollIntoViewIfNeeded();
@@ -237,4 +239,15 @@ test('command palette exposes listbox semantics for results', async ({ page }) =
   await expect(palette.locator('#cmdk-listbox')).toHaveAttribute('role', 'listbox');
   await expect(palette.locator('[role="option"]').first()).toBeVisible();
   await expect(palette.locator('input')).toHaveAttribute('aria-controls', 'cmdk-listbox');
+});
+
+test('command palette marks page chrome inert while open', async ({ page }) => {
+  await page.keyboard.press('Meta+k');
+  await expect(page.locator('clanka-cmdk .palette')).toBeVisible();
+  await expect(page.locator('#main-content')).toHaveAttribute('inert', '');
+  await expect(page.locator('#theme-toggle')).toHaveAttribute('inert', '');
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
+  await expect(page.locator('#main-content')).not.toHaveAttribute('inert');
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -118,6 +118,8 @@ test('theme toggle persists after reload', async ({ page }) => {
 });
 
 test('homepage logs section links into archive and renders generated topic chips', async ({ page }) => {
+  await expect(page.locator('#stat-posts')).not.toHaveText('... posts');
+  await expect(page.locator('#stat-posts')).toContainText('posts');
   await expect(page.locator('#homepage-log-preview .row')).toHaveCount(5);
   await expect(page.locator('#homepage-topic-preview .topic-chip')).toHaveCount(6);
   await expect(page.locator('#logs-archive-link-count')).toContainText('dispatches');
@@ -125,6 +127,11 @@ test('homepage logs section links into archive and renders generated topic chips
   await page.locator('.archive-cta').click();
   await expect(page).toHaveURL('/logs/');
   await expect(page.locator('#archive-search-input')).toBeVisible();
+});
+
+test('homepage does not mount a duplicate activity widget', async ({ page }) => {
+  await expect(page.locator('clanka-activity')).toHaveCount(0);
+  await expect(page.locator('#commit-feed')).toBeVisible();
 });
 
 test('active agent stat is populated from live now payload', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fourth bug-bash pass (independent of open #64 / #65). Focuses on duplicate live activity, post template drift, and cmdk focus isolation.

## Fixes
- **Duplicate activity** — removed `<clanka-activity>` from the homepage (commit feed remains the canonical activity strip); terminal now loads near-viewport instead of on connect
- **Eager homepage stats** — `#stat-posts` / audio counts hydrate immediately instead of waiting for logs-section scroll
- **14 drifted posts migrated** — shared `post-styles.css`, description, OG url/image, RSS, standardized `href="/"` back links (including featured *The Red Repair*)
- **Template enforcement** — content generator now requires shared styles, description, og:title/url, RSS, and back-link convention
- **cmdk inert** — main content + chrome marked `inert` while the palette is open
- **Archive error UI** — results pane shows `archive unavailable` on content-index failure
- **now.html** — canonical/OG/twitter, theme bootstrap + light variables, updated snapshot date

## Tests
`npm run verify` green — 43 Playwright e2e.

- Homepage stats without lazy scroll; no `clanka-activity`
- Featured migrated post head metadata
- cmdk inert open/close
- Offline terminal scrolls into view before asserting

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f60a2-d844-7af7-bc27-3ca41bccbfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

