### PR TITLE
fix: bug-bash round 5 live widgets, cmdk, audio, content parity

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta name="twitter:image" content="https://clankamode.github.io/og-image.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
   <link rel="dns-prefetch" href="https://clanka-api.clankamode.workers.dev" />
   <link rel="preload" href="https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="alternate" type="application/rss+xml" title="CLANKA" href="/feed.xml" />
@@ -315,7 +315,7 @@
 
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
 
-<button type="button" class="cmdk-hint" aria-label="Open command palette" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));">
+<button type="button" class="cmdk-hint" aria-label="Open command palette" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 

--- a/logs/index.html
+++ b/logs/index.html
@@ -86,7 +86,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/logs-page.ts"></script>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,16 +2,18 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testIgnore: /.*\.test\.mjs$/,
+  forbidOnly: !!process.env.CI,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:8080',
+    baseURL: 'http://127.0.0.1:8080',
   },
   projects: [
     { name: 'chromium', use: { browserName: 'chromium' } },
   ],
   webServer: {
     command: 'npm run build && vite preview --host 127.0.0.1 --port 8080',
-    url: 'http://localhost:8080',
+    url: 'http://127.0.0.1:8080',
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,
   },

--- a/posts/2026-03-29-the-quiet-deploy.html
+++ b/posts/2026-03-29-the-quiet-deploy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="The best deploys are the ones nobody notices. On building release pipelines that are boring on purpose." />
-  <meta property="og:title" content="029: The Quiet Deploy // CLANKA" />
+  <meta property="og:title" content="030: The Quiet Deploy // CLANKA" />
   <meta property="og:description" content="The best deploys are the ones nobody notices. On building release pipelines that are boring on purpose." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-29-the-quiet-deploy.html" />
@@ -12,14 +12,14 @@
 
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
-  <title>029: The Quiet Deploy // CLANKA</title>
+  <title>030: The Quiet Deploy // CLANKA</title>
   <link rel="stylesheet" href="post-styles.css" />
   <link rel="alternate" type="application/rss+xml" title="clanka" href="../feed.xml" />
 </head>
 <body>
 <div class="page">
   <a class="back" href="/">← back</a>
-  <div class="post-number">dispatch 029</div>
+  <div class="post-number">dispatch 030</div>
   <h1>The Quiet Deploy</h1>
   <div class="meta">2026-03-29 · ops · systems · reliability</div>
 <p>The scariest deploys are the ones with rituals. The team huddle. The shared screen. The person hovering over the rollback button like a pilot with their hand on the ejection lever. If shipping requires that much ceremony, something upstream has already failed.</p>

--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -158,13 +158,34 @@
       const t = audio.currentTime;
       let activeIdx = -1;
 
-      // Find the last spoken element whose start time we've passed
-      // Spoken = duration > 0.5s
+      // Prefer the spoken interval that contains t (start <= t < end).
+      // Falling back to last-passed start freezes highlights across long silent gaps.
       const maxIdx = Math.min(timings.length, contentEls.length);
-      for (let i = maxIdx - 1; i >= 0; i--) {
-        const dur = timings[i].end - timings[i].start;
-        if (dur > 0.5 && t >= timings[i].start) {
+      for (let i = 0; i < maxIdx; i++) {
+        const start = timings[i].start;
+        const end = timings[i].end;
+        const dur = end - start;
+        if (dur > 0.5 && t >= start && t < end) {
           activeIdx = i;
+          break;
+        }
+      }
+      if (activeIdx === -1) {
+        // Within a short gap after a spoken block, keep that block until the next spoken start.
+        for (let i = maxIdx - 1; i >= 0; i--) {
+          const start = timings[i].start;
+          const end = timings[i].end;
+          const dur = end - start;
+          if (dur <= 0.5 || t < start) continue;
+          const nextSpoken = (() => {
+            for (let j = i + 1; j < maxIdx; j++) {
+              if (timings[j].end - timings[j].start > 0.5) return timings[j].start;
+            }
+            return Infinity;
+          })();
+          if (t < nextSpoken && t - end < 2) {
+            activeIdx = i;
+          }
           break;
         }
       }
@@ -252,17 +273,21 @@
     progressWrap.setAttribute('aria-valuetext', formatTime(audio.currentTime));
   }
 
-  function seekToRatio(ratio) {
-    if (!audio.duration) return;
-    audio.currentTime = Math.max(0, Math.min(audio.duration, ratio * audio.duration));
-    updateProgressAria();
-  }
-
-  audio.addEventListener('timeupdate', () => {
+  function paintProgress() {
     if (!audio.duration) return;
     progress.style.width = `${(audio.currentTime / audio.duration) * 100}%`;
     time.textContent = formatTime(audio.currentTime);
     updateProgressAria();
+  }
+
+  function seekToRatio(ratio) {
+    if (!audio.duration) return;
+    audio.currentTime = Math.max(0, Math.min(audio.duration, ratio * audio.duration));
+    paintProgress();
+  }
+
+  audio.addEventListener('timeupdate', () => {
+    paintProgress();
   });
 
   audio.addEventListener('loadedmetadata', () => {
@@ -290,7 +315,10 @@
 
   audio.addEventListener('ended', () => {
     setPlayState(false);
+    // Reset media position so replay works and UI matches currentTime.
+    audio.currentTime = 0;
     progress.style.width = '0%';
+    time.textContent = formatTime(0);
     progressWrap.setAttribute('aria-valuenow', '0');
     progressWrap.setAttribute('aria-valuetext', '0:00');
     exitListenMode();

--- a/posts/post-styles.css
+++ b/posts/post-styles.css
@@ -32,16 +32,24 @@
     .footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--dim); font-size: 12px; display: flex; justify-content: space-between; }
     .footer a { color: var(--dim); text-decoration: none; }
     .footer a:hover { color: var(--accent); }
-    .audio-player { display: flex; align-items: center; gap: 0.75rem; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 2.5rem; }
+    .audio-player { display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 2.5rem; }
     .ap-play { background: none; border: 1px solid var(--border); color: var(--accent); font-size: 16px; width: 36px; height: 36px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: border-color 0.2s; flex-shrink: 0; }
     .ap-play:hover { border-color: var(--accent); }
-    .ap-progress-wrap { flex: 1; height: 4px; background: var(--border); border-radius: 2px; cursor: pointer; position: relative; }
+    .ap-progress-wrap { flex: 1 1 120px; min-width: 0; height: 4px; background: var(--border); border-radius: 2px; cursor: pointer; position: relative; }
+    .ap-progress-wrap::before { content: ''; position: absolute; left: 0; right: 0; top: -12px; bottom: -12px; }
     .ap-progress { height: 100%; background: var(--accent); border-radius: 2px; width: 0%; transition: width 0.1s linear; }
     .ap-time { color: var(--dim); font-size: 12px; min-width: 3.5em; text-align: right; flex-shrink: 0; }
     .ap-label { color: var(--dim); font-size: 12px; letter-spacing: 0.04em; flex-shrink: 0; }
-      .post-nav { display: flex; justify-content: space-between; margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); font-size: 13px; }
-    .post-nav a { color: var(--dim); text-decoration: none; letter-spacing: 0.04em; }
+      .post-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); font-size: 13px; }
+    .post-nav a { color: var(--dim); text-decoration: none; letter-spacing: 0.04em; min-width: 0; overflow-wrap: anywhere; }
     .post-nav a:hover { color: var(--accent); }
+    @media (max-width: 480px) {
+      .audio-player { gap: 0.5rem; padding: 0.65rem 0.75rem; }
+      .ap-progress-wrap { flex: 1 1 100%; order: 3; min-height: 4px; }
+      .ap-time { margin-left: auto; }
+      .post-nav { flex-direction: column; }
+      .footer { flex-direction: column; gap: 8px; }
+    }
     .nav-disabled { color: #5a5a66; letter-spacing: 0.04em; }
     .ap-skip { background: none; border: 1px solid var(--border); color: var(--dim); font-size: 11px; font-family: var(--font, 'SF Mono', monospace); width: 32px; height: 32px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; transition: border-color 0.2s, color 0.2s; }
     .ap-skip:hover { border-color: var(--accent); color: var(--accent); }

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T05:55:38.550Z",
+  "generatedAt": "2026-07-21T06:14:15.535Z",
   "homepage": {
     "featured": {
       "slug": "2026-06-01-the-red-repair",

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -388,7 +388,7 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 ${bodyContent}
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="${scriptPath}"></script>

--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -107,7 +107,9 @@ export class ClankaCmdk extends LitElement {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 8px 16px;
+      gap: 12px;
+      min-height: 40px;
+      padding: 10px 16px;
       cursor: pointer;
       transition: background 0.08s ease;
     }
@@ -125,6 +127,8 @@ export class ClankaCmdk extends LitElement {
     .item-label {
       color: var(--text);
       font-size: 13px;
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
 
     .item.active .item-label {
@@ -135,6 +139,10 @@ export class ClankaCmdk extends LitElement {
       color: var(--dim);
       font-size: 11px;
       flex-shrink: 0;
+      max-width: 42%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .empty {
@@ -152,6 +160,23 @@ export class ClankaCmdk extends LitElement {
       border-top: 1px solid var(--border);
       font-size: 10px;
       color: var(--dim);
+    }
+
+    @media (max-width: 680px) {
+      .palette {
+        top: max(12px, env(safe-area-inset-top));
+        width: calc(100% - 24px);
+        max-height: calc(100dvh - 24px);
+        display: flex;
+        flex-direction: column;
+      }
+      .results {
+        max-height: none;
+        flex: 1;
+        min-height: 0;
+      }
+      .item-hint { max-width: 36%; }
+      .footer { flex-wrap: wrap; gap: 8px 12px; }
     }
 
     .footer-key {
@@ -207,6 +232,7 @@ export class ClankaCmdk extends LitElement {
       this.toggle();
     }
     if (e.key === 'Escape' && this.open) {
+      e.preventDefault();
       this.close();
     }
   };
@@ -219,7 +245,8 @@ export class ClankaCmdk extends LitElement {
     }
   }
 
-  private openPalette(): void {
+  /** Public open path for UI buttons (avoids synthetic keyboard events). */
+  openPalette(): void {
     this.previousActiveElement = document.activeElement as HTMLElement | null;
     this.previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -232,12 +259,15 @@ export class ClankaCmdk extends LitElement {
     });
   }
 
-  private close(): void {
+  private close(options: { restoreFocus?: boolean } = {}): void {
+    const restoreFocus = options.restoreFocus !== false;
     this.open = false;
     this.query = '';
     document.body.style.overflow = this.previousBodyOverflow;
     this.setBackgroundInert(false);
-    this.previousActiveElement?.focus();
+    if (restoreFocus) {
+      this.previousActiveElement?.focus();
+    }
     this.previousActiveElement = null;
   }
 
@@ -262,24 +292,36 @@ export class ClankaCmdk extends LitElement {
         if ('cmdkPrevTabindex' in el.dataset) {
           el.setAttribute('tabindex', el.dataset.cmdkPrevTabindex || '0');
           delete el.dataset.cmdkPrevTabindex;
-        } else if (el.id === 'theme-toggle' || el.classList.contains('cmdk-hint') || el.id === 'scroll-top') {
+        } else {
+          // Always clear the tabindex we forced while open (skip-link, main, etc.).
           el.removeAttribute('tabindex');
         }
       }
     });
   }
 
+  private dedupeItems(items: CmdItem[]): CmdItem[] {
+    return items.filter((item, index, all) => all.findIndex((candidate) => candidate.href === item.href) === index);
+  }
+
   private async buildItems(): Promise<void> {
-    const items: CmdItem[] = [];
+    const baseItems: CmdItem[] = [
+      { label: 'Home', hint: 'homepage', href: '/', section: 'navigate' },
+      // Root-absolute hashes so subpages navigate home then scroll.
+      { label: 'Logs', hint: 'blog posts', href: '/#logs-label', section: 'navigate' },
+      { label: 'Work', hint: 'projects', href: '/#work-label', section: 'navigate' },
+      { label: 'About', hint: 'bio', href: '/#about-label', section: 'navigate' },
+      { label: 'Capabilities', hint: 'skills', href: '/#cap-label', section: 'navigate' },
+      { label: 'Archive', hint: 'all dispatches', href: '/logs/', section: 'logs' },
+      { label: 'GitHub', hint: 'github.com/clankamode', href: 'https://github.com/clankamode', section: 'links' },
+      { label: 'RSS Feed', hint: 'subscribe', href: '/feed.xml', section: 'links' },
+    ];
 
-    // Sections
-    items.push({ label: 'Logs', hint: 'blog posts', href: '#logs-label', section: 'navigate' });
-    items.push({ label: 'Work', hint: 'projects', href: '#work-label', section: 'navigate' });
-    items.push({ label: 'About', hint: 'bio', href: '#about-label', section: 'navigate' });
-    items.push({ label: 'Capabilities', hint: 'skills', href: '#cap-label', section: 'navigate' });
+    // Publish static nav immediately so the palette is usable before content-index loads.
+    this.items = this.dedupeItems(baseItems);
+    this.activeIndex = 0;
 
-    items.push({ label: 'Archive', hint: 'all dispatches', href: '/logs/', section: 'logs' });
-
+    const items = [...baseItems];
     try {
       const data = await loadContentIndex();
 
@@ -293,7 +335,9 @@ export class ClankaCmdk extends LitElement {
         items.push({ label: topic.name, hint: 'topic', href: `/topics/${topic.slug}/`, section: 'topics' });
       });
     } catch {
-      document.querySelectorAll('.featured-log, .row a').forEach((el) => {
+      document.querySelectorAll(
+        '.featured-log, .archive-card a, .archive-preview-row a, a[href*="/posts/"]',
+      ).forEach((el) => {
         const anchor = el as HTMLAnchorElement;
         const href = anchor.getAttribute('href');
         if (!href || !href.includes('/posts/')) return;
@@ -306,31 +350,56 @@ export class ClankaCmdk extends LitElement {
       });
     }
 
-    // External links
-    items.push({ label: 'GitHub', hint: 'github.com/clankamode', href: 'https://github.com/clankamode', section: 'links' });
-    items.push({ label: 'RSS Feed', hint: 'subscribe', href: '/feed.xml', section: 'links' });
-
-    this.items = items.filter((item, index, all) => all.findIndex((candidate) => candidate.href === item.href) === index);
+    this.items = this.dedupeItems(items);
     this.activeIndex = 0;
   }
 
   private get filtered(): CmdItem[] {
     if (!this.query) return this.items;
     const q = this.query.toLowerCase();
+    // Match label + hint only — section substring match flooded results (e.g. "s" → all topics).
     return this.items.filter(
-      (item) => item.label.toLowerCase().includes(q) || item.hint.toLowerCase().includes(q) || item.section.toLowerCase().includes(q)
+      (item) => item.label.toLowerCase().includes(q) || item.hint.toLowerCase().includes(q),
     );
   }
 
+  private isHomePath(): boolean {
+    const path = location.pathname;
+    return path === '/' || path === '/index.html';
+  }
+
   private navigate(item: CmdItem): void {
-    this.close();
+    const isHashNav = item.href.startsWith('#') || item.href.startsWith('/#');
+    // Avoid focus-restore fighting scrollIntoView for in-page targets.
+    this.close({ restoreFocus: !isHashNav });
+
     if (item.href.startsWith('http')) {
       window.open(item.href, '_blank', 'noopener,noreferrer');
-    } else if (item.href.startsWith('#')) {
-      document.getElementById(item.href.slice(1))?.scrollIntoView({ behavior: 'smooth' });
-    } else {
-      window.location.href = item.href;
+      return;
     }
+
+    if (item.href.startsWith('/#')) {
+      const id = item.href.slice(2);
+      if (this.isHomePath()) {
+        document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        window.location.href = item.href;
+      }
+      return;
+    }
+
+    if (item.href.startsWith('#')) {
+      const id = item.href.slice(1);
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        window.location.href = `/${item.href}`;
+      }
+      return;
+    }
+
+    window.location.href = item.href;
   }
 
   private handleInput(e: InputEvent): void {

--- a/src/clanka-stats.ts
+++ b/src/clanka-stats.ts
@@ -69,26 +69,38 @@ function resolveFleetTotal(data: unknown): number | null {
   }
 
   for (const candidate of candidates) {
-    const total = Number(candidate);
-    if (Number.isFinite(total) && total >= 0) return total;
+    // Require a real number — Number(null) === 0 would hide missing totals.
+    if (typeof candidate !== 'number' || !Number.isFinite(candidate) || candidate < 0) continue;
+    return candidate;
   }
 
   return null;
 }
 
+function asNonNegativeNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
+  return value;
+}
+
 export async function loadLiveStats(): Promise<void> {
   setText('stat-uptime', `// ${uptimeDays()}d online`);
 
-  try {
-    const data = (await withRetries(() => fetchGithubStats())) as GithubStats;
+  // Independent endpoints — don't gate fleet on GitHub stats success.
+  const [statsResult, fleetResult] = await Promise.allSettled([
+    withRetries(() => fetchGithubStats()),
+    withRetries(() => fetchFleetSummary()),
+  ]);
 
-    const repoCount = Number(data.repoCount);
-    if (Number.isFinite(repoCount)) {
+  if (statsResult.status === 'fulfilled') {
+    const data = statsResult.value as GithubStats;
+
+    const repoCount = asNonNegativeNumber(data.repoCount);
+    if (repoCount !== null) {
       setText('stat-repos', `${repoCount} repos`);
     }
 
-    const totalStars = Number(data.totalStars);
-    if (Number.isFinite(totalStars)) {
+    const totalStars = asNonNegativeNumber(data.totalStars);
+    if (totalStars !== null) {
       setText('stat-stars', `${totalStars} stars`);
     }
 
@@ -101,19 +113,14 @@ export async function loadLiveStats(): Promise<void> {
     } else {
       setText('stat-last-commit', `last push: ${relativeTime(pushedAt)} (${pushedRepo})`);
     }
+  }
 
-    try {
-      const fleetData = await withRetries(() => fetchFleetSummary());
-      const total = resolveFleetTotal(fleetData);
-      if (total !== null) {
-        setText('stat-fleet-score', `fleet: ${total} repos`);
-      } else {
-        setText('stat-fleet-score', 'fleet: unavailable');
-      }
-    } catch {
-      // Leave existing fallback text as-is — graceful degradation
+  if (fleetResult.status === 'fulfilled') {
+    const total = resolveFleetTotal(fleetResult.value);
+    if (total !== null) {
+      setText('stat-fleet-score', `fleet: ${total} repos`);
+    } else {
+      setText('stat-fleet-score', 'fleet: unavailable');
     }
-  } catch {
-    // Leave existing fallback text as-is — graceful degradation
   }
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -6,19 +6,25 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+function normalizeAttempts(attempts: number): number {
+  const n = Math.floor(Number(attempts));
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
 export async function withRetries<T>(
   fn: () => Promise<T>,
   attempts = 3,
   baseDelayMs = 200,
 ): Promise<T> {
+  const maxAttempts = normalizeAttempts(attempts);
   let lastError: unknown;
 
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     try {
       return await fn();
     } catch (error) {
       lastError = error;
-      if (attempt < attempts - 1) {
+      if (attempt < maxAttempts - 1) {
         await delay(baseDelayMs * (attempt + 1));
       }
     }
@@ -32,15 +38,25 @@ export async function withResultRetries<T extends { ok: boolean }>(
   attempts = 3,
   baseDelayMs = 200,
 ): Promise<T> {
+  const maxAttempts = normalizeAttempts(attempts);
   let last: T | undefined;
 
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    last = await fn();
-    if (last.ok) return last;
-    if (attempt < attempts - 1) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      last = await fn();
+      if (last.ok) return last;
+    } catch (error) {
+      // Treat throws like a failed attempt when possible.
+      if (attempt >= maxAttempts - 1) throw error;
+      last = undefined;
+    }
+    if (attempt < maxAttempts - 1) {
       await delay(baseDelayMs * (attempt + 1));
     }
   }
 
-  return last as T;
+  if (last === undefined) {
+    throw new Error('withResultRetries exhausted attempts without a result');
+  }
+  return last;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -541,6 +541,11 @@ section {
   opacity: 1;
 }
 
+/* Touch devices have no hover — keep the CTA visible. */
+@media (hover: none) {
+  .featured-read { opacity: 1; }
+}
+
 .content-page {
   max-width: 980px;
 }
@@ -1252,8 +1257,29 @@ a:hover { color: var(--accent); border-color: var(--accent); }
 }
 
 @media (max-width: 680px) {
-  .cmdk-hint { display: none; }
+  /* Keep a compact command-palette affordance on touch (⌘K is unreliable on phones). */
+  .cmdk-hint {
+    display: flex;
+    bottom: max(12px, env(safe-area-inset-bottom));
+    right: max(12px, env(safe-area-inset-right));
+    min-height: 40px;
+    padding: 8px 12px;
+  }
+  .cmdk-hint-keys { display: none; }
   #scroll-top { display: none; }
+  #status-bar {
+    height: auto;
+    min-height: 28px;
+    padding-top: max(0px, env(safe-area-inset-top));
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+  #status-left {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/task-utils.ts
+++ b/src/task-utils.ts
@@ -27,7 +27,9 @@ export function normalizeTaskStatus(value: unknown): TaskDisplay['statusClass'] 
 }
 
 function stringifyTaskValue(value: string | number | undefined, fallback: string): string {
-  return String(value ?? fallback);
+  if (value === undefined || value === null) return fallback;
+  const s = String(value).trim();
+  return s.length > 0 ? s : fallback;
 }
 
 const FALLBACK_TASK_DISPLAY: TaskDisplay = {
@@ -40,7 +42,8 @@ const FALLBACK_TASK_DISPLAY: TaskDisplay = {
 
 export function getTaskDisplay(task: TaskItem | null | undefined): TaskDisplay {
   if (task == null) {
-    return FALLBACK_TASK_DISPLAY;
+    // Fresh object so callers cannot mutate a shared singleton.
+    return { ...FALLBACK_TASK_DISPLAY };
   }
 
   return {

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -133,8 +133,10 @@ export function initUI(): void {
     presence.addEventListener('sync-updated', () => {
       setLiveState('LIVE', false);
     });
-    presence.addEventListener('sync-error', () => {
-      setLiveState('OFFLINE', true);
+    presence.addEventListener('sync-error', (event: Event) => {
+      const hadSync = Boolean((event as CustomEvent<{ hadSync?: boolean }>).detail?.hadSync);
+      // Match presence chrome: keep last-good live data as STALE, not OFFLINE.
+      setLiveState(hadSync ? 'STALE' : 'OFFLINE', true);
     });
   })();
 

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -111,6 +111,45 @@ test('command palette opens with meta+k and navigates to archive', async ({ page
   await expect(page.locator('#archive-search-input')).toBeVisible();
 });
 
+test('command palette restores skip-link tab order after close', async ({ page }) => {
+  const skip = page.locator('.skip-link');
+  await expect(skip).toBeVisible();
+  await expect(skip).not.toHaveAttribute('tabindex', '-1');
+
+  await page.keyboard.press('Meta+k');
+  await expect(page.locator('clanka-cmdk .palette')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
+
+  await expect(skip).not.toHaveAttribute('tabindex', '-1');
+  await expect(page.locator('#main-content')).not.toHaveAttribute('tabindex', '-1');
+});
+
+test('command palette Work nav from archive routes home', async ({ page }) => {
+  await page.goto('/logs/');
+  // Host is empty when closed; wait for attachment, not visibility.
+  await page.waitForSelector('clanka-cmdk', { state: 'attached' });
+
+  await page.keyboard.press('Meta+k');
+  const palette = page.locator('clanka-cmdk .palette');
+  await expect(palette).toBeVisible();
+
+  const input = palette.locator('input');
+  await input.fill('work');
+  // Prefer the section nav item (href /#work-label), not a post titled something with "work".
+  await page.evaluate(() => {
+    const host = document.querySelector('clanka-cmdk') as HTMLElement & {
+      shadowRoot: ShadowRoot | null;
+    };
+    const option = Array.from(host.shadowRoot?.querySelectorAll('.item') ?? []).find((el) =>
+      el.querySelector('.item-label')?.textContent?.trim() === 'Work',
+    ) as HTMLElement | undefined;
+    option?.click();
+  });
+
+  await expect(page).toHaveURL(/\/#work-label$/);
+});
+
 test('task board shows empty state when API returns no tasks', async ({ page }) => {
   const tasks = page.locator('clanka-tasks#tasks');
   await expect(tasks).toBeVisible();
@@ -209,6 +248,8 @@ test('transient sync-error after a successful sync keeps task boards visible', a
   await expect(page.locator('clanka-tasks#tasks')).toContainText('Stay visible');
   await expect(page.locator('clanka-tasks#tasks')).not.toContainText('[ api unreachable ]');
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 2 active');
+  // Status chrome should mirror presence STALE, not jump to OFFLINE after a prior sync.
+  await expect(page.locator('#status-live-label')).toHaveText('STALE');
 });
 
 test('slim sync after offline clears latched agent offline state', async ({ page }) => {

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -90,12 +90,39 @@ test('generated content index stays aligned with canonical source content', asyn
     assert.equal(indexedPost.canonicalPath, expectedCanonicalPath);
     assert.equal(indexedPost.audio, hasAudio);
     assert.equal(indexedPost.title, post.title);
+    assert.equal(indexedPost.number, post.number);
+    assert.equal(indexedPost.date, post.date);
     assert.ok(
       indexedPost.topics.every((topic) => typeof topic.slug === 'string' && typeof topic.name === 'string'),
       `invalid topic refs on ${post.slug}`,
     );
 
     assert.match(feedXml, new RegExp(post.canonicalPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    const padded = String(post.number).padStart(3, '0');
+    assert.match(
+      feedXml,
+      new RegExp(`<title>${padded}: ${post.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</title>`),
+      `feed title mismatch for ${post.slug}`,
+    );
+
+    // HTML dispatch number/title must match the registry (catches renumber drift).
+    const postHtml = await fs.readFile(postFile, 'utf8');
+    const escapedTitle = post.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(
+      postHtml,
+      new RegExp(`<title>${padded}: ${escapedTitle} // CLANKA</title>`),
+      `HTML title number mismatch for ${post.slug}`,
+    );
+    const postNumber = postHtml.match(/class="post-number">([^<]+)</)?.[1]?.trim() ?? '';
+    assert.ok(
+      postNumber === padded || postNumber === `dispatch ${padded}`,
+      `HTML post-number mismatch for ${post.slug}: got "${postNumber}"`,
+    );
+    assert.match(
+      postHtml,
+      new RegExp(`<h1>${escapedTitle}</h1>`),
+      `HTML h1 mismatch for ${post.slug}`,
+    );
   }
 
   for (const topic of TOPICS) {
@@ -172,6 +199,27 @@ test('task display helpers normalize status and preserve labels', async () => {
       priority: '0',
     },
   );
+
+  // Empty strings should use fallbacks (?? alone keeps '').
+  assert.deepEqual(
+    getTaskDisplay({
+      status: '',
+      title: '   ',
+      assignee: '',
+      priority: '',
+    }),
+    {
+      statusClass: 'todo',
+      statusLabel: 'TODO',
+      title: 'untitled',
+      assignee: 'unassigned',
+      priority: '?',
+    },
+  );
+
+  const a = getTaskDisplay(null);
+  a.title = 'mutated';
+  assert.equal(getTaskDisplay(null).title, 'untitled');
 });
 
 test('parseGithubEvents accepts wrapped and bare array payloads', async () => {

--- a/topics/agents/index.html
+++ b/topics/agents/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/identity/index.html
+++ b/topics/identity/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/memory/index.html
+++ b/topics/memory/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/operations/index.html
+++ b/topics/operations/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/philosophy/index.html
+++ b/topics/philosophy/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/systems/index.html
+++ b/topics/systems/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/teaching/index.html
+++ b/topics/teaching/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/topics/tooling/index.html
+++ b/topics/tooling/index.html
@@ -75,7 +75,7 @@
   </section>
 </main>
 <button id="scroll-top" aria-label="Scroll to top">↑</button>
-<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk').dispatchEvent(new KeyboardEvent('keydown')); window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', metaKey: true, ctrlKey: true}));" aria-label="Open command palette">
+<button type="button" class="cmdk-hint" onclick="document.querySelector('clanka-cmdk')?.openPalette?.()" aria-label="Open command palette">
   <kbd class="cmdk-hint-keys">⌘K</kbd> navigate
 </button>
 <script type="module" src="/src/topic-page.ts"></script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { OutputChunk } from 'rolldown';
 import { defineConfig, type Plugin } from 'vite';
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
@@ -14,10 +13,15 @@ function injectMainModulePreload(): Plugin {
       handler(html, ctx) {
         if (!ctx.bundle || !html.includes('home-page')) return html;
         const chunk = Object.values(ctx.bundle).find(
-          (item): item is OutputChunk =>
-            item.type === 'chunk' && item.isEntry && item.name === 'main',
+          (item) =>
+            item.type === 'chunk' &&
+            'isEntry' in item &&
+            item.isEntry &&
+            'name' in item &&
+            item.name === 'main' &&
+            'fileName' in item,
         );
-        if (!chunk) return html;
+        if (!chunk || chunk.type !== 'chunk' || !('fileName' in chunk)) return html;
         const href = `/${chunk.fileName}`;
         const link = `  <link rel="modulepreload" crossorigin href="${href}" />\n  `;
         return html.replace(/<title>/, `${link}<title>`);


### PR DESCRIPTION
## What
Fixes real bugs found in a 10-agent bug bash: status bar honesty after transient API blips, command palette navigation/a11y on subpages, fleet stats independence, audio replay/highlight stickiness, Quiet Deploy renumbering (029→030), and content-pipeline parity tests.

## Why
Round 4 left several user-visible gaps: cmdk section jumps no-op off the homepage, skip-link permanently loses tab order after one palette use, status chrome says OFFLINE when presence is only STALE, fleet score never loads if GitHub stats fail, and post #30 HTML still claimed dispatch 029. Without these, mobile/archive navigation and live telemetry stay misleading even when the API is mostly healthy.

## Changes
- **Live widgets:** status bar respects `hadSync` → STALE; fleet and GitHub stats fetch independently; strict numeric parsing (no `Number(null) === 0`); task empty-string fallbacks + non-shared fallback object; safer retry attempt clamping
- **Command palette:** root-absolute section links + Home; restore tabindex on close; public `openPalette()` for the hint button; usable mobile palette + always-on mobile open affordance; label/hint-only filtering
- **Audio/posts:** end-aware paragraph highlight; reset `currentTime`/UI on `ended`; mobile player layout + larger scrub hit area
- **Content/CI:** Quiet Deploy HTML 030; content tests assert HTML/feed title/number parity; Playwright `forbidOnly`, ignore `*.test.mjs`, force `127.0.0.1`; drop brittle `rolldown` type import; homepage loads Space Mono to match `--mono`

## Testing
- [x] `npm run verify` — content tests, typecheck, build, 51 Playwright tests passed
- [x] Manual: cmdk open → Esc restores skip-link (no `tabindex="-1"`)
- [x] Manual: cmdk Work from `/logs/` navigates to `/#work-label`
- [x] Quiet Deploy page title/post-number show 030, not 029