### PR TITLE
fix: bug-bash round 6 live stats, presence, and content hardening

### DIFF
--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -79,9 +79,22 @@
   let timings = null;
   const timingsEl = document.getElementById('audio-timings');
   if (timingsEl) {
-    try { timings = JSON.parse(timingsEl.textContent); } catch(e) {}
+    try {
+      const parsed = JSON.parse(timingsEl.textContent);
+      if (Array.isArray(parsed)) {
+        const normalized = [];
+        for (const entry of parsed) {
+          if (!entry || typeof entry !== 'object') continue;
+          const start = Number(entry.start);
+          const end = Number(entry.end);
+          if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
+          normalized.push({ start, end });
+        }
+        if (normalized.length > 0) timings = normalized;
+      }
+    } catch (e) {}
   }
-  const hasTimings = timings && timings.length > 0;
+  const hasTimings = Array.isArray(timings) && timings.length > 0;
 
   // --- Web Audio Analyzer ---
   function initAudio() {

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T06:14:15.535Z",
+  "generatedAt": "2026-07-21T18:37:59.264Z",
   "homepage": {
     "featured": {
       "slug": "2026-06-01-the-red-repair",

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T18:37:59.264Z",
+  "generatedAt": "2026-07-21T18:38:17.744Z",
   "homepage": {
     "featured": {
       "slug": "2026-06-01-the-red-repair",

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -51,8 +51,42 @@ function parsePublishedAt(date) {
   return Date.parse(`${date}T00:00:00Z`);
 }
 
+function isValidPostDate(date) {
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+
+  const parsed = parsePublishedAt(date);
+  if (!Number.isFinite(parsed)) return false;
+
+  const utc = new Date(parsed);
+  const yyyy = String(utc.getUTCFullYear()).padStart(4, '0');
+  const mm = String(utc.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(utc.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}` === date;
+}
+
 function formatPubDate(date) {
   return new Date(`${date}T00:00:00Z`).toUTCString();
+}
+
+function parseAudioTimingsJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') return null;
+    const start = entry.start;
+    const end = entry.end;
+    if (typeof start !== 'number' || !Number.isFinite(start) || start < 0) return null;
+    if (typeof end !== 'number' || !Number.isFinite(end) || end < start) return null;
+  }
+
+  return parsed;
 }
 
 function filePathFromCanonical(canonicalPath) {
@@ -86,6 +120,10 @@ async function validateInputs(posts, topics) {
 
     if (!post.summary?.trim()) {
       throw new Error(`Missing summary for ${post.slug}`);
+    }
+
+    if (!isValidPostDate(post.date)) {
+      throw new Error(`Invalid post date for ${post.slug}: expected YYYY-MM-DD, got ${post.date}`);
     }
 
     if (!Array.isArray(post.topics) || post.topics.length === 0) {
@@ -124,6 +162,15 @@ async function validateInputs(posts, topics) {
       throw new Error(
         `Missing #audio-timings for ${post.slug} (audio=true). Embed Whisper timings or run whisper_sync.py.`,
       );
+    }
+    if (post.audio) {
+      const timingsMatch = postHtml.match(/<script\b[^>]*\bid=["']audio-timings["'][^>]*>([\s\S]*?)<\/script>/i);
+      const timings = timingsMatch ? parseAudioTimingsJson(timingsMatch[1].trim()) : null;
+      if (!timings) {
+        throw new Error(
+          `Invalid #audio-timings JSON for ${post.slug}: expected a non-empty array of {start,end} numbers.`,
+        );
+      }
     }
     if (!postHtml.includes('post-styles.css')) {
       throw new Error(`Missing shared post-styles.css for ${post.slug}`);

--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -14,6 +14,10 @@ function endpoint(path: string): string {
   return `${API_BASE}${path}`;
 }
 
+function invalidateEndpoint(path: string): void {
+  responseCache.delete(endpoint(path));
+}
+
 async function fetchJson(path: string, ttlMs = DEFAULT_TTL_MS): Promise<unknown> {
   const url = endpoint(path);
   const cached = responseCache.get(url);
@@ -168,6 +172,8 @@ export async function fetchNow(): Promise<NowPayload> {
   const data = await fetchJson('/now');
   const parsed = parseNowPayload(data);
   if (!parsed) {
+    // Don't keep a rejected shape in the shared TTL cache.
+    invalidateEndpoint('/now');
     throw new Error('Invalid /now payload');
   }
   return parsed;

--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -102,6 +102,10 @@ export class ClankaPresence extends LitElement {
     if (!this.hasAttribute('tabindex')) {
       this.tabIndex = 0;
     }
+    // firstUpdated only runs once per instance — reconnect must re-arm polling
+    // and refresh so a mid-flight disconnect cannot leave the widget stuck.
+    this.ensurePolling();
+    void this.updatePresence();
   }
 
   disconnectedCallback(): void {
@@ -112,9 +116,8 @@ export class ClankaPresence extends LitElement {
     super.disconnectedCallback();
   }
 
-  async firstUpdated() {
-    await this.updatePresence();
-    if (!this.isConnected) return;
+  private ensurePolling(): void {
+    if (this.pollId !== undefined) return;
     this.pollId = window.setInterval(() => void this.updatePresence(), 30000);
   }
 

--- a/src/clanka-stats.ts
+++ b/src/clanka-stats.ts
@@ -95,14 +95,10 @@ export async function loadLiveStats(): Promise<void> {
     const data = statsResult.value as GithubStats;
 
     const repoCount = asNonNegativeNumber(data.repoCount);
-    if (repoCount !== null) {
-      setText('stat-repos', `${repoCount} repos`);
-    }
+    setText('stat-repos', repoCount !== null ? `${repoCount} repos` : 'repos unavailable');
 
     const totalStars = asNonNegativeNumber(data.totalStars);
-    if (totalStars !== null) {
-      setText('stat-stars', `${totalStars} stars`);
-    }
+    setText('stat-stars', totalStars !== null ? `${totalStars} stars` : 'stars unavailable');
 
     const pushedAt = parsePushedAt(data.lastPushedAt);
     const pushedRepo = typeof data.lastPushedRepo === 'string' ? data.lastPushedRepo.trim() : '';
@@ -113,6 +109,10 @@ export async function loadLiveStats(): Promise<void> {
     } else {
       setText('stat-last-commit', `last push: ${relativeTime(pushedAt)} (${pushedRepo})`);
     }
+  } else {
+    setText('stat-repos', 'repos unavailable');
+    setText('stat-stars', 'stars unavailable');
+    setText('stat-last-commit', 'last push: unavailable');
   }
 
   if (fleetResult.status === 'fulfilled') {
@@ -122,5 +122,7 @@ export async function loadLiveStats(): Promise<void> {
     } else {
       setText('stat-fleet-score', 'fleet: unavailable');
     }
+  } else {
+    setText('stat-fleet-score', 'fleet: unavailable');
   }
 }

--- a/src/content-index.ts
+++ b/src/content-index.ts
@@ -54,7 +54,11 @@ function isTopicRef(value: unknown): value is ContentTopicRef {
   if (!value || typeof value !== 'object') return false;
 
   const topic = value as Partial<ContentTopicRef>;
-  return typeof topic.slug === 'string' && typeof topic.name === 'string';
+  return (
+    typeof topic.slug === 'string' &&
+    typeof topic.name === 'string' &&
+    typeof topic.description === 'string'
+  );
 }
 
 function isPostSummary(value: unknown): value is ContentPostSummary {
@@ -64,9 +68,26 @@ function isPostSummary(value: unknown): value is ContentPostSummary {
   return (
     typeof post.slug === 'string' &&
     typeof post.title === 'string' &&
+    typeof post.date === 'string' &&
+    typeof post.summary === 'string' &&
     typeof post.canonicalPath === 'string' &&
+    typeof post.number === 'number' &&
+    Number.isFinite(post.number) &&
     Array.isArray(post.topics) &&
     post.topics.every(isTopicRef)
+  );
+}
+
+function isContentTopic(value: unknown): value is ContentTopic {
+  if (!isTopicRef(value)) return false;
+
+  const topic = value as Partial<ContentTopic>;
+  return (
+    typeof topic.count === 'number' &&
+    Number.isFinite(topic.count) &&
+    (topic.latestDate === null || typeof topic.latestDate === 'string') &&
+    Array.isArray(topic.posts) &&
+    topic.posts.every(isPostSummary)
   );
 }
 
@@ -89,11 +110,18 @@ function isContentIndex(value: unknown): value is ContentIndex {
     Array.isArray(candidate.posts) &&
     candidate.posts.every(isPostSummary) &&
     Array.isArray(candidate.topics) &&
+    candidate.topics.every(isContentTopic) &&
     !!candidate.homepage &&
+    (candidate.homepage.featured === null ||
+      candidate.homepage.featured === undefined ||
+      isPostSummary(candidate.homepage.featured)) &&
     Array.isArray(candidate.homepage.recent) &&
+    candidate.homepage.recent.every(isPostSummary) &&
     Array.isArray(candidate.homepage.topics) &&
+    candidate.homepage.topics.every(isContentTopic) &&
     countsOk &&
-    Array.isArray(candidate.homepage.years)
+    Array.isArray(candidate.homepage.years) &&
+    candidate.homepage.years.every((year) => typeof year === 'number' && Number.isFinite(year))
   );
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,7 +94,9 @@ if (presence) {
       setText('stat-active-agents', `agents: ${activeAgents} active`);
     } else {
       const el = document.getElementById('stat-active-agents');
-      if (el?.textContent === 'agents: offline') {
+      const current = el?.textContent ?? '';
+      // Clear loading/offline placeholders; keep a previously resolved count on slim syncs.
+      if (current === 'agents: offline' || current === 'agents: ...' || current === '') {
         setText('stat-active-agents', 'agents: —');
       }
     }

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -307,3 +307,86 @@ test('withRetries eventually succeeds and withResultRetries stops on ok', async 
   assert.deepEqual(result, { ok: true, n: 2 });
   assert.equal(resultAttempts, 2);
 });
+
+test('post dates are valid YYYY-MM-DD and generator validates dates and audio timings', async () => {
+  const [{ POSTS }, generatorSource] = await Promise.all([
+    loadSourceContent(),
+    fs.readFile(path.join(ROOT, 'scripts/generate-site-content.mjs'), 'utf8'),
+  ]);
+
+  assert.match(generatorSource, /isValidPostDate/);
+  assert.match(generatorSource, /parseAudioTimingsJson/);
+
+  for (const post of POSTS) {
+    assert.match(post.date, /^\d{4}-\d{2}-\d{2}$/, `date shape for ${post.slug}`);
+    const parsed = Date.parse(`${post.date}T00:00:00Z`);
+    assert.ok(Number.isFinite(parsed), `date parse for ${post.slug}`);
+    const utc = new Date(parsed);
+    const yyyy = String(utc.getUTCFullYear()).padStart(4, '0');
+    const mm = String(utc.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(utc.getUTCDate()).padStart(2, '0');
+    assert.equal(`${yyyy}-${mm}-${dd}`, post.date, `date round-trip for ${post.slug}`);
+  }
+});
+
+test('loadContentIndex rejects malformed topic entries', async () => {
+  const { loadContentIndex } = await loadTsModule('src/content-index.ts');
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => ({
+    ok: true,
+    async json() {
+      return {
+        generatedAt: '2026-03-18T00:00:00.000Z',
+        homepage: {
+          featured: null,
+          recent: [],
+          topics: [{ slug: 'ops' }],
+          counts: { posts: 0, audioPosts: 0, topics: 1 },
+          years: [],
+        },
+        posts: [],
+        topics: [{ slug: 'ops' }],
+      };
+    },
+  });
+
+  try {
+    await assert.rejects(loadContentIndex(), /invalid content index payload/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchNow invalidates cache after rejecting a malformed payload', async () => {
+  const { fetchNow } = await loadTsModule('src/clanka-api.ts');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return {
+        ok: true,
+        async json() {
+          return {};
+        },
+      };
+    }
+    return {
+      ok: true,
+      async json() {
+        return { current: 'recovered', status: 'active' };
+      },
+    };
+  };
+
+  try {
+    await assert.rejects(fetchNow(), /Invalid \/now payload/);
+    const recovered = await fetchNow();
+    assert.deepEqual(recovered, { current: 'recovered', status: 'active' });
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -165,3 +165,35 @@ test('homepage archive stats show unavailable when content-index fails', async (
   await expect(page.locator('#stat-audio-posts')).toHaveText('audio unavailable');
   await expect(page.locator('#logs-archive-link-count')).toHaveText('archive unavailable');
 });
+
+test('homepage repo stats show unavailable when live APIs fail', async ({ page }) => {
+  await page.route(`${API_BASE}/github/stats`, async (route) => {
+    await route.abort('failed');
+  });
+  await page.route(`${API_BASE}/fleet/summary`, async (route) => {
+    await route.abort('failed');
+  });
+
+  await page.reload();
+  await expect(page.locator('#stat-repos')).toHaveText('repos unavailable');
+  await expect(page.locator('#stat-stars')).toHaveText('stars unavailable');
+  await expect(page.locator('#stat-last-commit')).toHaveText('last push: unavailable');
+  await expect(page.locator('#stat-fleet-score')).toHaveText('fleet: unavailable');
+});
+
+test('slim initial /now without agent count clears agents placeholder', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'presence only',
+        status: 'active',
+      }),
+    });
+  });
+
+  await page.reload();
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: —');
+  await expect(page.locator('#status-live-label')).toHaveText('LIVE');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bug-bash round 6 fixes leftover correctness gaps after rounds 1–5:

- **Live stats:** rejected `/github/stats` or `/fleet/summary` (and malformed fields) now clear `...` placeholders to honest `unavailable` copy instead of leaving them stuck.
- **Active agents:** a successful slim `/now` sync without agent count data clears the initial `agents: ...` placeholder to `agents: —` (still preserves a previously resolved count on partial syncs).
- **Presence:** polling + refresh are re-armed from `connectedCallback`, so a mid-flight disconnect/reconnect can no longer leave the widget stuck without polling.
- **API cache:** invalid `/now` payloads are removed from the shared TTL cache so a bad response cannot poison recovery.
- **Content index:** topic objects (and homepage topic/recent arrays) are fully validated before consumers assume `name`/`description`/`posts`.
- **Content pipeline:** post dates must be real `YYYY-MM-DD` values; audio posts must embed valid `{start,end}` timing JSON. The audio player also filters malformed timing entries at runtime.

## Tests
- Added content-index unit coverage for date/timings validation markers, malformed topic rejection, and `/now` cache invalidation.
- Added homepage Playwright coverage for stats API failure and slim initial `/now`.
- `npm run verify` passed locally (9 content tests, typecheck, build, 53 Playwright tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f85f1-b983-7f1d-ba30-552b6c45dd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f85f1-b983-7f1d-ba30-552b6c45dd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

