### PR TITLE
ci: harden Playwright with retries and failure artifacts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,9 +4,12 @@ export default defineConfig({
   testDir: './tests',
   testIgnore: /.*\.test\.mjs$/,
   forbidOnly: !!process.env.CI,
-  reporter: 'list',
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['github']] : 'list',
   use: {
     baseURL: 'http://127.0.0.1:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
   projects: [
     { name: 'chromium', use: { browserName: 'chromium' } },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Playwright currently runs with no retries and no failure artifacts, which makes CI flakes hard to diagnose.

- Retry failed tests twice in CI (`retries: 2`)
- Capture traces on first retry and screenshots on failure
- Use the GitHub reporter in CI for inline annotations

## Test plan
- [x] `npm run verify` (Node 24) passes locally
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3def4ed4-87e0-43a0-a424-fd1bd291899a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3def4ed4-87e0-43a0-a424-fd1bd291899a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

