### PR TITLE
fix(a11y): cmdk scroll-lock, aria-expanded, and reduced motion

### DIFF
--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -209,12 +209,23 @@ export class ClankaCmdk extends LitElement {
       from { opacity: 0; transform: translateX(-50%) translateY(-8px) scale(0.98); }
       to { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      .backdrop,
+      .palette {
+        animation: none;
+      }
+      .item {
+        transition: none;
+      }
+    }
   `;
 
   connectedCallback(): void {
     super.connectedCallback();
     void this.buildItems();
     window.addEventListener('keydown', this.handleGlobalKey);
+    this.setCmdkHintExpanded(false);
   }
 
   disconnectedCallback(): void {
@@ -223,6 +234,7 @@ export class ClankaCmdk extends LitElement {
     if (this.open) {
       document.body.style.overflow = this.previousBodyOverflow;
       this.setBackgroundInert(false);
+      this.setCmdkHintExpanded(false);
     }
   }
 
@@ -247,10 +259,19 @@ export class ClankaCmdk extends LitElement {
 
   /** Public open path for UI buttons (avoids synthetic keyboard events). */
   openPalette(): void {
+    // Re-entrant open must not overwrite the pre-open overflow/inert snapshot.
+    if (this.open) {
+      this.updateComplete.then(() => {
+        this.shadowRoot?.querySelector('input')?.focus();
+      });
+      return;
+    }
+
     this.previousActiveElement = document.activeElement as HTMLElement | null;
     this.previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     this.setBackgroundInert(true);
+    this.setCmdkHintExpanded(true);
     this.open = true;
     this.query = '';
     this.activeIndex = 0;
@@ -265,10 +286,23 @@ export class ClankaCmdk extends LitElement {
     this.query = '';
     document.body.style.overflow = this.previousBodyOverflow;
     this.setBackgroundInert(false);
+    this.setCmdkHintExpanded(false);
     if (restoreFocus) {
       this.previousActiveElement?.focus();
     }
     this.previousActiveElement = null;
+  }
+
+  private setCmdkHintExpanded(expanded: boolean): void {
+    document.querySelectorAll('.cmdk-hint').forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      el.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      el.setAttribute('aria-haspopup', 'dialog');
+    });
+  }
+
+  private scrollBehavior(): ScrollBehavior {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
   }
 
   private setBackgroundInert(inert: boolean): void {
@@ -381,7 +415,7 @@ export class ClankaCmdk extends LitElement {
     if (item.href.startsWith('/#')) {
       const id = item.href.slice(2);
       if (this.isHomePath()) {
-        document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+        document.getElementById(id)?.scrollIntoView({ behavior: this.scrollBehavior() });
       } else {
         window.location.href = item.href;
       }
@@ -392,7 +426,7 @@ export class ClankaCmdk extends LitElement {
       const id = item.href.slice(1);
       const el = document.getElementById(id);
       if (el) {
-        el.scrollIntoView({ behavior: 'smooth' });
+        el.scrollIntoView({ behavior: this.scrollBehavior() });
       } else {
         window.location.href = `/${item.href}`;
       }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -335,3 +335,35 @@ test('command palette marks page chrome inert while open', async ({ page }) => {
   await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
   await expect(page.locator('#main-content')).not.toHaveAttribute('inert');
 });
+
+test('command palette syncs aria-expanded on the open trigger', async ({ page }) => {
+  const hint = page.locator('.cmdk-hint');
+  await expect(hint).toHaveAttribute('aria-expanded', 'false');
+  await expect(hint).toHaveAttribute('aria-haspopup', 'dialog');
+
+  await page.keyboard.press('Meta+k');
+  await expect(page.locator('clanka-cmdk .palette')).toBeVisible();
+  await expect(hint).toHaveAttribute('aria-expanded', 'true');
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
+  await expect(hint).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('command palette re-open does not leave body scroll locked after close', async ({ page }) => {
+  await page.evaluate(() => {
+    document.body.style.overflow = '';
+    const host = document.querySelector('clanka-cmdk') as HTMLElement & {
+      openPalette?: () => void;
+    };
+    host.openPalette?.();
+    host.openPalette?.();
+  });
+
+  await expect(page.locator('clanka-cmdk .palette')).toBeVisible();
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('hidden');
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make `openPalette()` idempotent so a second open does not overwrite the pre-open `body` overflow snapshot (scroll-lock stuck after Escape).
- Sync `aria-expanded` / `aria-haspopup` on `.cmdk-hint` when the palette opens and closes.
- Disable cmdk shadow-DOM enter animations under `prefers-reduced-motion`, and use non-smooth `scrollIntoView` for in-page hash navigation when reduced motion is requested.

## Test plan
- [x] `npm run verify` (Node 24)
- [x] New Playwright coverage for `aria-expanded` toggle and re-entrant open scroll-lock restore
- [ ] Manual: open palette via hint button / ⌘K, confirm Escape restores page scroll and trigger state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f544ca-5786-4bfc-b079-c132c6e24596?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f544ca-5786-4bfc-b079-c132c6e24596&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

