### PR TITLE
fix(a11y): clamp reading progress and mark it decorative

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="home-page">
   <div class="home-composition">

--- a/logs/index.html
+++ b/logs/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -419,7 +419,7 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1016,10 +1016,12 @@ a:hover { color: var(--accent); border-color: var(--accent); }
   left: 0;
   height: 2px;
   width: 0%;
+  max-width: 100%;
   background: linear-gradient(90deg, var(--accent), rgba(200, 245, 66, 0.4));
   z-index: 9990;
   transition: width 60ms linear;
   box-shadow: 0 0 8px rgba(200, 245, 66, 0.4);
+  pointer-events: none;
 }
 
 .cmdk-hint {
@@ -1300,6 +1302,9 @@ a:hover { color: var(--accent); border-color: var(--accent); }
     opacity: 1 !important;
     transform: none !important;
     animation: none !important;
+  }
+  .scroll-progress {
+    transition: none !important;
   }
 }
 

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -62,13 +62,20 @@ export function initUI(): void {
     });
   })();
 
-  // Scroll progress bar
+  // Scroll progress bar (decorative visual chrome)
   (() => {
     const bar = document.getElementById('scrollProgress');
     if (!bar) return;
+    bar.setAttribute('aria-hidden', 'true');
     const update = () => {
       const h = document.documentElement.scrollHeight - window.innerHeight;
-      bar.style.width = h > 0 ? `${(window.scrollY / h) * 100}%` : '0%';
+      if (h <= 0) {
+        bar.style.width = '0%';
+        return;
+      }
+      // Clamp: rubber-band / overscroll can push scrollY outside [0, h].
+      const pct = Math.min(100, Math.max(0, (window.scrollY / h) * 100));
+      bar.style.width = `${pct}%`;
     };
     window.addEventListener('scroll', update, { passive: true });
     window.addEventListener('resize', update, { passive: true });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -197,3 +197,21 @@ test('slim initial /now without agent count clears agents placeholder', async ({
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: —');
   await expect(page.locator('#status-live-label')).toHaveText('LIVE');
 });
+
+test('reading progress bar stays decorative and clamped at scroll extremes', async ({ page }) => {
+  const bar = page.locator('#scrollProgress');
+  await expect(bar).toHaveAttribute('aria-hidden', 'true');
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect.poll(async () => page.locator('#scrollProgress').evaluate((el) => el.style.width)).toBe('0%');
+
+  await page.evaluate(() => {
+    const max = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+    window.scrollTo(0, max + 400);
+  });
+  await expect.poll(async () => {
+    const width = await page.locator('#scrollProgress').evaluate((el) => el.style.width);
+    const value = Number.parseFloat(width);
+    return Number.isFinite(value) && value >= 0 && value <= 100;
+  }).toBe(true);
+});

--- a/topics/agents/index.html
+++ b/topics/agents/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/identity/index.html
+++ b/topics/identity/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/memory/index.html
+++ b/topics/memory/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/operations/index.html
+++ b/topics/operations/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/philosophy/index.html
+++ b/topics/philosophy/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/systems/index.html
+++ b/topics/systems/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/teaching/index.html
+++ b/topics/teaching/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">

--- a/topics/tooling/index.html
+++ b/topics/tooling/index.html
@@ -39,7 +39,7 @@
 </div>
 <button id="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">theme: dark</button>
 <div class="grain-overlay" aria-hidden="true"></div>
-<div class="scroll-progress" id="scrollProgress"></div>
+<div class="scroll-progress" id="scrollProgress" aria-hidden="true"></div>
 <clanka-cmdk></clanka-cmdk>
 <main id="main-content" class="content-page">
   <nav class="page-nav" aria-label="Breadcrumb">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Mark `#scrollProgress` as `aria-hidden` (decorative chrome) in hand-authored and generated shells.
- Clamp progress width to `0–100%` so overscroll/rubber-banding cannot widen past the viewport.
- Disable the progress width transition under `prefers-reduced-motion`, and keep the bar non-interactive (`pointer-events: none`).

## Test plan
- [x] `npm run verify` (Node 24)
- [x] Playwright: decorative attribute + clamped width at scroll extremes
- [ ] Manual: scroll homepage/archive with reduced motion enabled and confirm no progress-bar animation chatter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f544ca-5786-4bfc-b079-c132c6e24596?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f544ca-5786-4bfc-b079-c132c6e24596&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

