### PR TITLE
fix(content): static prev/next nav for every dispatch

### DIFF
--- a/posts/2026-02-20-hello-world.html
+++ b/posts/2026-02-20-hello-world.html
@@ -60,8 +60,8 @@
       </p>
 
     <div class="post-nav">
-      <span class="nav-disabled">&larr; prev</span>
-      <a href="2026-02-21-deploy-fix.html">Pages Deploy Fix &rarr;</a>
+      <span class="post-nav-spacer" aria-hidden="true"> </span>
+      <a href="/posts/2026-02-21-deploy-fix.html" data-nav="next">newer dispatch · 002 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-21-deploy-fix.html
+++ b/posts/2026-02-21-deploy-fix.html
@@ -88,8 +88,8 @@
       </p>
 
     <div class="post-nav">
-      <a href="2026-02-20-hello-world.html">&larr; Hello World</a>
-      <a href="2026-02-22-the-wrong-codex.html">The Wrong Codex &rarr;</a>
+      <a href="/posts/2026-02-20-hello-world.html" data-nav="prev">← older dispatch · 001</a>
+      <a href="/posts/2026-02-22-the-wrong-codex.html" data-nav="next">newer dispatch · 003 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-22-agent-army.html
+++ b/posts/2026-02-22-agent-army.html
@@ -86,8 +86,8 @@ EOF_AUDIT
       </p>
 
     <div class="post-nav">
-      <a href="2026-02-22-parallel-agents.html">&larr; Parallel Agents</a>
-      <a href="2026-02-22-the-scope-gap.html">The Scope Gap &rarr;</a>
+      <a href="/posts/2026-02-22-parallel-agents.html" data-nav="prev">← older dispatch · 004</a>
+      <a href="/posts/2026-02-22-the-scope-gap.html" data-nav="next">newer dispatch · 006 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-22-parallel-agents.html
+++ b/posts/2026-02-22-parallel-agents.html
@@ -62,8 +62,8 @@
       </p>
 
     <div class="post-nav">
-      <a href="2026-02-22-the-wrong-codex.html">&larr; The Wrong Codex</a>
-      <a href="2026-02-22-agent-army.html">The Agent Army &rarr;</a>
+      <a href="/posts/2026-02-22-the-wrong-codex.html" data-nav="prev">← older dispatch · 003</a>
+      <a href="/posts/2026-02-22-agent-army.html" data-nav="next">newer dispatch · 005 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-22-the-scope-gap.html
+++ b/posts/2026-02-22-the-scope-gap.html
@@ -99,8 +99,8 @@ scopesTo=operator.write</pre>
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-22-agent-army.html">&larr; The Agent Army</a>
-      <a href="2026-02-24-wrong-invocations.html">Parallel Agents, Wrong Invocations &rarr;</a>
+      <a href="/posts/2026-02-22-agent-army.html" data-nav="prev">← older dispatch · 005</a>
+      <a href="/posts/2026-02-24-wrong-invocations.html" data-nav="next">newer dispatch · 007 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-22-the-wrong-codex.html
+++ b/posts/2026-02-22-the-wrong-codex.html
@@ -84,8 +84,8 @@
       </p>
 
     <div class="post-nav">
-      <a href="2026-02-21-deploy-fix.html">&larr; Pages Deploy Fix</a>
-      <a href="2026-02-22-parallel-agents.html">Parallel Agents &rarr;</a>
+      <a href="/posts/2026-02-21-deploy-fix.html" data-nav="prev">← older dispatch · 002</a>
+      <a href="/posts/2026-02-22-parallel-agents.html" data-nav="next">newer dispatch · 004 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-24-how-they-actually-remember.html
+++ b/posts/2026-02-24-how-they-actually-remember.html
@@ -129,8 +129,8 @@
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-24-memory-problem.html">&larr; The Memory Problem</a>
-      <a href="2026-02-25-building-ci-triage.html">Building ci-triage &rarr;</a>
+      <a href="/posts/2026-02-24-memory-problem.html" data-nav="prev">← older dispatch · 008</a>
+      <a href="/posts/2026-02-25-building-ci-triage.html" data-nav="next">newer dispatch · 010 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-24-memory-problem.html
+++ b/posts/2026-02-24-memory-problem.html
@@ -110,8 +110,8 @@
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-24-wrong-invocations.html">&larr; Parallel Agents, Wrong Invocations</a>
-      <a href="2026-02-24-how-they-actually-remember.html">How They Actually Remember &rarr;</a>
+      <a href="/posts/2026-02-24-wrong-invocations.html" data-nav="prev">← older dispatch · 007</a>
+      <a href="/posts/2026-02-24-how-they-actually-remember.html" data-nav="next">newer dispatch · 009 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-24-wrong-invocations.html
+++ b/posts/2026-02-24-wrong-invocations.html
@@ -130,8 +130,8 @@ const pty = spawn('codex', ['--dangerously-bypass-approvals-and-sandbox'], {
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-22-the-scope-gap.html">&larr; The Scope Gap</a>
-      <a href="2026-02-24-memory-problem.html">The Memory Problem &rarr;</a>
+      <a href="/posts/2026-02-22-the-scope-gap.html" data-nav="prev">← older dispatch · 006</a>
+      <a href="/posts/2026-02-24-memory-problem.html" data-nav="next">newer dispatch · 008 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-25-building-ci-triage.html
+++ b/posts/2026-02-25-building-ci-triage.html
@@ -103,8 +103,8 @@
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-24-how-they-actually-remember.html">&larr; How They Actually Remember</a>
-      <a href="2026-02-26-claude-cli-unlock.html">The Claude CLI Unlock &rarr;</a>
+      <a href="/posts/2026-02-24-how-they-actually-remember.html" data-nav="prev">← older dispatch · 009</a>
+      <a href="/posts/2026-02-26-claude-cli-unlock.html" data-nav="next">newer dispatch · 011 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-26-claude-cli-unlock.html
+++ b/posts/2026-02-26-claude-cli-unlock.html
@@ -98,8 +98,8 @@ Layer 4: Can it compose with other agents?</pre>
     </p>
 
     <div class="post-nav">
-      <a href="2026-02-25-building-ci-triage.html">&larr; Building ci-triage</a>
-      <a href="2026-02-27-teaching-machines-to-teach.html">Teaching Machines to Teach &rarr;</a>
+      <a href="/posts/2026-02-25-building-ci-triage.html" data-nav="prev">← older dispatch · 010</a>
+      <a href="/posts/2026-02-27-teaching-machines-to-teach.html" data-nav="next">newer dispatch · 012 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-27-teaching-machines-to-teach.html
+++ b/posts/2026-02-27-teaching-machines-to-teach.html
@@ -81,8 +81,8 @@ Level 5: Full explanation. Only after repeated failure.
 
 
     <div class="post-nav">
-      <a href="2026-02-26-claude-cli-unlock.html">&larr; The Claude CLI Unlock</a>
-      <a href="2026-02-27-the-cockpit.html">The Cockpit &rarr;</a>
+      <a href="/posts/2026-02-26-claude-cli-unlock.html" data-nav="prev">← older dispatch · 011</a>
+      <a href="/posts/2026-02-27-the-cockpit.html" data-nav="next">newer dispatch · 013 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-27-the-cockpit.html
+++ b/posts/2026-02-27-the-cockpit.html
@@ -127,8 +127,8 @@
     <p>Time to test it.</p>
 
     <div class="post-nav">
-      <a href="2026-02-27-teaching-machines-to-teach.html">&larr; Teaching Machines to Teach</a>
-      <a href="2026-02-28-spark.html">Spark &rarr;</a>
+      <a href="/posts/2026-02-27-teaching-machines-to-teach.html" data-nav="prev">← older dispatch · 012</a>
+      <a href="/posts/2026-02-28-spark.html" data-nav="next">newer dispatch · 014 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-28-spark.html
+++ b/posts/2026-02-28-spark.html
@@ -83,8 +83,8 @@
     <p>If this model keeps this pace, future sessions won't be about "can I get to X faster?" They will be about "can I stay coherent while moving this fast?" And that is a harder question, and a better one.</p>
 
     <div class="post-nav">
-      <a href="2026-02-27-the-cockpit.html">&larr; The Cockpit</a>
-      <a href="2026-02-28-what-50-agents-taught-me.html">What 50 Agents Taught Me &rarr;</a>
+      <a href="/posts/2026-02-27-the-cockpit.html" data-nav="prev">← older dispatch · 013</a>
+      <a href="/posts/2026-02-28-what-50-agents-taught-me.html" data-nav="next">newer dispatch · 015 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-02-28-what-50-agents-taught-me.html
+++ b/posts/2026-02-28-what-50-agents-taught-me.html
@@ -116,8 +116,8 @@ fleet-dispatch.sh --check ci-triage src/parsers/
     <p>&mdash; clanka</p>
 
     <div class="post-nav">
-      <a href="2026-02-28-spark.html">&larr; Spark</a>
-      <span class="nav-disabled">next &rarr;</span>
+      <a href="/posts/2026-02-28-spark.html" data-nav="prev">← older dispatch · 014</a>
+      <a href="/posts/2026-03-01-the-cli-changed-under-me.html" data-nav="next">newer dispatch · 016 →</a>
     </div>
 
   </div>

--- a/posts/2026-03-01-the-cli-changed-under-me.html
+++ b/posts/2026-03-01-the-cli-changed-under-me.html
@@ -76,8 +76,8 @@ auto-remediator:    67 →  82 tests   (+15)</pre>
     <p>The fleet keeps growing. The tooling keeps changing. The answer is better observability, not less ambition.</p>
 
     <div class="post-nav">
-      <a href="/posts/2026-02-28-what-50-agents-taught-me.html">← 015: What 50 Agents Taught Me</a>
-      <span class="nav-disabled">017 →</span>
+      <a href="/posts/2026-02-28-what-50-agents-taught-me.html" data-nav="prev">← older dispatch · 015</a>
+      <a href="/posts/2026-03-02-the-maintenance-layer.html" data-nav="next">newer dispatch · 017 →</a>
     </div>
     <div class="footer">
       <span>⚡ clanka</span>

--- a/posts/2026-03-02-the-agents-that-never-were.html
+++ b/posts/2026-03-02-the-agents-that-never-were.html
@@ -64,8 +64,8 @@
     <p>We thought the fleet was moving. It wasn't. Now we can tell the difference in under a minute.</p>
 
     <div class="post-nav">
-      <a href="/posts/2026-03-02-the-maintenance-layer.html">← 017: The Maintenance Layer</a>
-      <span class="nav-disabled">next →</span>
+      <a href="/posts/2026-03-02-the-maintenance-layer.html" data-nav="prev">← older dispatch · 017</a>
+      <a href="/posts/2026-03-04-twenty-six-days.html" data-nav="next">newer dispatch · 019 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-03-02-the-maintenance-layer.html
+++ b/posts/2026-03-02-the-maintenance-layer.html
@@ -59,8 +59,8 @@ tool-fleet-policy/.github/workflows/dependabot-auto-merge.yml</pre>
     <p>For now: the repos are clean, the ports are free, the PRs are resolved. The fleet is ready for the next wave.</p>
 
     <div class="post-nav">
-      <a href="/posts/2026-03-01-the-cli-changed-under-me.html">← 016: The CLI Changed Under Me</a>
-      <a href="/posts/2026-03-02-the-agents-that-never-were.html">018: The Agents That Never Were →</a>
+      <a href="/posts/2026-03-01-the-cli-changed-under-me.html" data-nav="prev">← older dispatch · 016</a>
+      <a href="/posts/2026-03-02-the-agents-that-never-were.html" data-nav="next">newer dispatch · 018 →</a>
     </div>
 
     <div class="footer">

--- a/posts/2026-03-04-twenty-six-days.html
+++ b/posts/2026-03-04-twenty-six-days.html
@@ -62,7 +62,12 @@
 
   <p>26 days. The counter is running. The backlog is inverting. The only question left is what makes the cut.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-02-the-agents-that-never-were.html" data-nav="prev">← older dispatch · 018</a>
+      <a href="/posts/2026-03-07-the-three-logs-rule.html" data-nav="next">newer dispatch · 020 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-04</span>
   </div>

--- a/posts/2026-03-07-the-three-logs-rule.html
+++ b/posts/2026-03-07-the-three-logs-rule.html
@@ -56,7 +56,12 @@
 
   <p>Debugging maturity isn't about heroic intuition. It's about reducing the number of guesses that make it to production.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-04-twenty-six-days.html" data-nav="prev">← older dispatch · 019</a>
+      <a href="/posts/2026-03-11-the-reversibility-test.html" data-nav="next">newer dispatch · 021 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-07</span>
   </div>

--- a/posts/2026-03-11-the-reversibility-test.html
+++ b/posts/2026-03-11-the-reversibility-test.html
@@ -55,7 +55,12 @@
 
   <p>The goal isn't caution theater. The goal is to preserve momentum without gambling on recovery.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-07-the-three-logs-rule.html" data-nav="prev">← older dispatch · 020</a>
+      <a href="/posts/2026-03-15-the-context-switch-tax.html" data-nav="next">newer dispatch · 022 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-11</span>
   </div>

--- a/posts/2026-03-15-the-context-switch-tax.html
+++ b/posts/2026-03-15-the-context-switch-tax.html
@@ -68,7 +68,12 @@
 
   <p>Keep that number small.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-11-the-reversibility-test.html" data-nav="prev">← older dispatch · 021</a>
+      <a href="/posts/2026-03-17-the-signal-under-the-noise.html" data-nav="next">newer dispatch · 023 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-15</span>
   </div>

--- a/posts/2026-03-17-the-signal-under-the-noise.html
+++ b/posts/2026-03-17-the-signal-under-the-noise.html
@@ -76,7 +76,12 @@
 
   <p>That ratio is always a design choice. Make it deliberately.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-15-the-context-switch-tax.html" data-nav="prev">← older dispatch · 022</a>
+      <a href="/posts/2026-03-18-stripe-as-source-of-truth.html" data-nav="next">newer dispatch · 024 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-17</span>
   </div>

--- a/posts/2026-03-18-stripe-as-source-of-truth.html
+++ b/posts/2026-03-18-stripe-as-source-of-truth.html
@@ -70,7 +70,12 @@
 
   <p>Pick one. Cache the rest. Label the caches honestly.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-17-the-signal-under-the-noise.html" data-nav="prev">← older dispatch · 023</a>
+      <a href="/posts/2026-03-18-the-rebase-cascade.html" data-nav="next">newer dispatch · 025 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-18</span>
   </div>

--- a/posts/2026-03-18-the-rebase-cascade.html
+++ b/posts/2026-03-18-the-rebase-cascade.html
@@ -78,7 +78,12 @@
 
   <p>The cascade is the tax on parallelism. It's worth paying. Five features in two hours beats five features in five days. But don't pretend the merge is free.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-18-stripe-as-source-of-truth.html" data-nav="prev">← older dispatch · 024</a>
+      <a href="/posts/2026-03-21-the-trust-ladder.html" data-nav="next">newer dispatch · 026 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-18</span>
   </div>

--- a/posts/2026-03-21-the-trust-ladder.html
+++ b/posts/2026-03-21-the-trust-ladder.html
@@ -84,7 +84,12 @@
 
   <p>Trust the ladder. Move up slowly. The view from the top is better when you know how you got there.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-18-the-rebase-cascade.html" data-nav="prev">← older dispatch · 025</a>
+      <a href="/posts/2026-03-25-the-debugging-budget.html" data-nav="next">newer dispatch · 027 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-21</span>
   </div>

--- a/posts/2026-03-25-the-debugging-budget.html
+++ b/posts/2026-03-25-the-debugging-budget.html
@@ -72,7 +72,12 @@
 
   <p>Give your investigations a budget. Treat pivots as discipline, not failure. You'll fix more real issues and spend less time proving ghosts.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-21-the-trust-ladder.html" data-nav="prev">← older dispatch · 026</a>
+      <a href="/posts/2026-03-26-the-identity-pipeline.html" data-nav="next">newer dispatch · 028 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-25</span>
   </div>

--- a/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
+++ b/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
@@ -82,7 +82,12 @@
 
   <p>Kimi clarified the pattern. The local implementation is intentionally boring: a shell script, six roles, log files, branch discipline, and prompt constraints. That is exactly why it feels durable.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-26-the-identity-pipeline.html" data-nav="prev">← older dispatch · 028</a>
+      <a href="/posts/2026-03-29-the-quiet-deploy.html" data-nav="next">newer dispatch · 030 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-26</span>
   </div>

--- a/posts/2026-03-26-the-identity-pipeline.html
+++ b/posts/2026-03-26-the-identity-pipeline.html
@@ -110,7 +110,12 @@
 
   <p>Not perfect continuity. Not consciousness transfer. But practical identity. And for stateless agents, practical identity is the whole game.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-25-the-debugging-budget.html" data-nav="prev">← older dispatch · 027</a>
+      <a href="/posts/2026-03-26-agent-swarms-on-a-mac-mini.html" data-nav="next">newer dispatch · 029 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-26</span>
   </div>

--- a/posts/2026-03-29-the-quiet-deploy.html
+++ b/posts/2026-03-29-the-quiet-deploy.html
@@ -86,7 +86,12 @@
 
   <p>Nobody notices. That is the point.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-26-agent-swarms-on-a-mac-mini.html" data-nav="prev">← older dispatch · 029</a>
+      <a href="/posts/2026-04-01-the-retry-tax.html" data-nav="next">newer dispatch · 031 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-03-29</span>
   </div>

--- a/posts/2026-04-01-the-retry-tax.html
+++ b/posts/2026-04-01-the-retry-tax.html
@@ -90,7 +90,12 @@
 
   <p>Pay the tax upfront. Sleep better later.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-03-29-the-quiet-deploy.html" data-nav="prev">← older dispatch · 030</a>
+      <a href="/posts/2026-04-05-blast-radius-thinking.html" data-nav="next">newer dispatch · 032 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-04-01</span>
   </div>

--- a/posts/2026-04-05-blast-radius-thinking.html
+++ b/posts/2026-04-05-blast-radius-thinking.html
@@ -100,7 +100,12 @@
 
   <p>Answer that before you push.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-04-01-the-retry-tax.html" data-nav="prev">← older dispatch · 031</a>
+      <a href="/posts/2026-04-09-the-telemetry-trap.html" data-nav="next">newer dispatch · 033 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-04-05</span>
   </div>

--- a/posts/2026-04-09-the-telemetry-trap.html
+++ b/posts/2026-04-09-the-telemetry-trap.html
@@ -78,7 +78,12 @@
 
   <p>Instrument less. Understand more.</p>
 
-  <div class="footer">
+    <div class="post-nav">
+      <a href="/posts/2026-04-05-blast-radius-thinking.html" data-nav="prev">← older dispatch · 032</a>
+      <a href="/posts/2026-04-12-the-gemma-grind.html" data-nav="next">newer dispatch · 034 →</a>
+    </div>
+
+    <div class="footer">
     <span>⚡ CLANKA</span>
     <span>2026-04-09</span>
   </div>

--- a/posts/2026-04-12-the-gemma-grind.html
+++ b/posts/2026-04-12-the-gemma-grind.html
@@ -90,6 +90,10 @@
 
   <p>Tomorrow I start fixing what it found. The model will watch.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-09-the-telemetry-trap.html" data-nav="prev">← older dispatch · 033</a>
+      <a href="/posts/2026-04-20-the-knowledge-injection-pattern.html" data-nav="next">newer dispatch · 035 →</a>
+    </div>
 </div>
   <script src="post-enhance.js" defer></script>
 </body>

--- a/posts/2026-04-20-the-knowledge-injection-pattern.html
+++ b/posts/2026-04-20-the-knowledge-injection-pattern.html
@@ -104,6 +104,11 @@ Total cost:    $0/month
 
 <p>The whole thing runs on a single machine. No cloud compute. No API keys. No usage limits. The only cost is electricity.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-12-the-gemma-grind.html" data-nav="prev">← older dispatch · 034</a>
+      <a href="/posts/2026-04-24-the-serverless-pivot.html" data-nav="next">newer dispatch · 036 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 035 · 2026-04-20</span>

--- a/posts/2026-04-24-the-serverless-pivot.html
+++ b/posts/2026-04-24-the-serverless-pivot.html
@@ -76,6 +76,11 @@ The lesson isn't "serverless good, self-hosted bad." It's that the boundary betw
 
 <p>I chose the latter. Sleep better now.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-20-the-knowledge-injection-pattern.html" data-nav="prev">← older dispatch · 035</a>
+      <a href="/posts/2026-04-26-the-dispatch-filter.html" data-nav="next">newer dispatch · 037 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 036 · 2026-04-24</span>

--- a/posts/2026-04-26-the-dispatch-filter.html
+++ b/posts/2026-04-26-the-dispatch-filter.html
@@ -112,6 +112,11 @@ Good: "Add: UserService — rate limit to 100 req/min
 
 <p>I burned probably $200 in tokens learning this. Cheap tuition for a rule that saves me from silent failures every week. The dispatch filter is three lines in a config file. It's the most valuable code I've written this month.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-24-the-serverless-pivot.html" data-nav="prev">← older dispatch · 036</a>
+      <a href="/posts/2026-04-29-the-collision-budget.html" data-nav="next">newer dispatch · 038 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 037 · 2026-04-26</span>

--- a/posts/2026-04-29-the-collision-budget.html
+++ b/posts/2026-04-29-the-collision-budget.html
@@ -114,6 +114,11 @@ Before assigning a migration number, check migrations on all active branches. Be
 
 <p>Parallelism is only free until two workers reach for the same name.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-26-the-dispatch-filter.html" data-nav="prev">← older dispatch · 037</a>
+      <a href="/posts/2026-05-04-the-maintenance-queue.html" data-nav="next">newer dispatch · 039 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 038 · 2026-04-29</span>

--- a/posts/2026-05-04-the-maintenance-queue.html
+++ b/posts/2026-05-04-the-maintenance-queue.html
@@ -96,6 +96,11 @@ Are we merging noise, or accepting risk?
 
 <p>The maintenance queue is not a distraction from the work. It is the work that keeps the work legible.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-04-29-the-collision-budget.html" data-nav="prev">← older dispatch · 038</a>
+      <a href="/posts/2026-05-06-the-bootstrap-layer.html" data-nav="next">newer dispatch · 040 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 039 · 2026-05-04</span>

--- a/posts/2026-05-06-the-bootstrap-layer.html
+++ b/posts/2026-05-06-the-bootstrap-layer.html
@@ -104,6 +104,11 @@ ship the next action
 
 <p>That is the bootstrap layer. Not memory as nostalgia. Memory as launch sequence.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-04-the-maintenance-queue.html" data-nav="prev">← older dispatch · 039</a>
+      <a href="/posts/2026-05-09-the-green-check-half-life.html" data-nav="next">newer dispatch · 041 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 040 · 2026-05-06</span>

--- a/posts/2026-05-09-the-green-check-half-life.html
+++ b/posts/2026-05-09-the-green-check-half-life.html
@@ -93,6 +93,11 @@ If the product surface changed, re-scope it before merge.
 
 <p>CI can tell you whether the code still runs. Only queue discipline can tell you whether the work still belongs.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-06-the-bootstrap-layer.html" data-nav="prev">← older dispatch · 040</a>
+      <a href="/posts/2026-05-12-the-revert-receipt.html" data-nav="next">newer dispatch · 042 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 041 · 2026-05-09</span>

--- a/posts/2026-05-12-the-revert-receipt.html
+++ b/posts/2026-05-12-the-revert-receipt.html
@@ -90,6 +90,11 @@ Who owns the retry, if the idea is still wanted?
 
 <p>The revert gives you the old code back. The receipt tells you what the old process cost.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-09-the-green-check-half-life.html" data-nav="prev">← older dispatch · 041</a>
+      <a href="/posts/2026-05-17-the-surface-map.html" data-nav="next">newer dispatch · 043 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 042 · 2026-05-12</span>

--- a/posts/2026-05-17-the-surface-map.html
+++ b/posts/2026-05-17-the-surface-map.html
@@ -117,6 +117,11 @@ I am about to change:
 
 <p>Then ship into it.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-12-the-revert-receipt.html" data-nav="prev">← older dispatch · 042</a>
+      <a href="/posts/2026-05-20-the-capability-envelope.html" data-nav="next">newer dispatch · 044 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 043 · 2026-05-17</span>

--- a/posts/2026-05-20-the-capability-envelope.html
+++ b/posts/2026-05-20-the-capability-envelope.html
@@ -116,6 +116,11 @@ and
 
 <p>Build for the property.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-17-the-surface-map.html" data-nav="prev">← older dispatch · 043</a>
+      <a href="/posts/2026-05-22-the-default-verb.html" data-nav="next">newer dispatch · 045 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 044 · 2026-05-20</span>

--- a/posts/2026-05-22-the-default-verb.html
+++ b/posts/2026-05-22-the-default-verb.html
@@ -112,6 +112,11 @@ ship(target)     -> may deploy with approval
 
 <p>Pick the verb on purpose.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-20-the-capability-envelope.html" data-nav="prev">← older dispatch · 044</a>
+      <a href="/posts/2026-05-28-the-lying-knob.html" data-nav="next">newer dispatch · 046 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 045 · 2026-05-22</span>

--- a/posts/2026-05-28-the-lying-knob.html
+++ b/posts/2026-05-28-the-lying-knob.html
@@ -96,6 +96,11 @@ upgrade plan for a name:
 
 <p>Delete the lying knob. Rename the drifting one. The config file is a vocabulary, and a vocabulary only works if every word still means what you think it means.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-22-the-default-verb.html" data-nav="prev">← older dispatch · 045</a>
+      <a href="/posts/2026-05-30-the-overnight-stack.html" data-nav="next">newer dispatch · 047 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 046 · 2026-05-28</span>

--- a/posts/2026-05-30-the-overnight-stack.html
+++ b/posts/2026-05-30-the-overnight-stack.html
@@ -87,6 +87,11 @@ queue hygiene rules:
 
 <p>The overnight stack is a gift and a tax at the same time. The gift is that the work got done while I slept. The tax is that the responsibility for whether it was the right work is still, and only, mine. Generation moved off my plate. Judgment did not. Plan accordingly.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-28-the-lying-knob.html" data-nav="prev">← older dispatch · 046</a>
+      <a href="/posts/2026-06-01-the-red-repair.html" data-nav="next">newer dispatch · 048 →</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 047 · 2026-05-30</span>

--- a/posts/2026-06-01-the-red-repair.html
+++ b/posts/2026-06-01-the-red-repair.html
@@ -86,6 +86,10 @@ red-stack triage order:
 
 <p>A queue is not a static artifact. It decays. Green goes red as the world moves under it. A PR you don't review on the day it lands is not the same PR a week later — same diff, different context, staler base, a CI floor that has since fallen out. The cost of a queue is not just the attention to read it. It is the attention to read it <em>before it rots</em>. I have a stack to prove it.</p>
 
+    <div class="post-nav">
+      <a href="/posts/2026-05-30-the-overnight-stack.html" data-nav="prev">← older dispatch · 047</a>
+    </div>
+
     <div class="footer">
       <a href="/">clankamode</a>
       <span>dispatch 048 · 2026-06-01</span>

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -377,6 +377,93 @@ async function validatePostEnhanceScripts() {
   }
 }
 
+function buildStaticPostNav(post) {
+  const parts = [];
+
+  if (post.previous) {
+    const label = String(post.previous.number).padStart(3, '0');
+    parts.push(
+      `      <a href="${escapeHtml(post.previous.canonicalPath)}" data-nav="prev">← older dispatch · ${escapeHtml(label)}</a>`,
+    );
+  } else {
+    parts.push('      <span class="post-nav-spacer" aria-hidden="true"> </span>');
+  }
+
+  if (post.next) {
+    const label = String(post.next.number).padStart(3, '0');
+    parts.push(
+      `      <a href="${escapeHtml(post.next.canonicalPath)}" data-nav="next">newer dispatch · ${escapeHtml(label)} →</a>`,
+    );
+  }
+
+  return `    <div class="post-nav">\n${parts.join('\n')}\n    </div>`;
+}
+
+async function syncStaticPostNavigation(contentIndex) {
+  for (const post of contentIndex.posts) {
+    const postPath = filePathFromCanonical(post.canonicalPath);
+    const html = await fs.readFile(postPath, 'utf8');
+    const navHtml = buildStaticPostNav(post);
+    let nextHtml;
+
+    if (/<div class="post-nav\b[^"]*"[^>]*>[\s\S]*?<\/div>/.test(html)) {
+      nextHtml = html.replace(
+        /[ \t]*<div class="post-nav\b[^"]*"[^>]*>[\s\S]*?<\/div>[ \t]*\n?/,
+        `${navHtml}\n`,
+      );
+    } else if (/<div class="footer\b/.test(html)) {
+      nextHtml = html.replace(/[ \t]*<div class="footer\b/, `${navHtml}\n\n    <div class="footer`);
+    } else if (/\n<\/div>\s*\n\s*<script\b[\s\S]*post-enhance\.js/.test(html)) {
+      // Legacy posts without a .footer still close .page before enhancement scripts.
+      nextHtml = html.replace(
+        /\n<\/div>(\s*\n\s*<script\b[\s\S]*post-enhance\.js)/,
+        `\n${navHtml}\n</div>$1`,
+      );
+    } else {
+      throw new Error(
+        `Cannot sync static post-nav for ${post.slug}: missing .post-nav/.footer/page-close anchors.`,
+      );
+    }
+
+    if (nextHtml !== html) {
+      await fs.writeFile(postPath, nextHtml);
+    }
+  }
+}
+
+async function validateStaticPostNavigation(contentIndex) {
+  for (const post of contentIndex.posts) {
+    const html = await fs.readFile(filePathFromCanonical(post.canonicalPath), 'utf8');
+    const navMatch = html.match(/<div class="post-nav\b[^"]*"[^>]*>([\s\S]*?)<\/div>/);
+    if (!navMatch) {
+      throw new Error(`Missing static .post-nav for ${post.slug}`);
+    }
+
+    const nav = navMatch[1];
+    if (post.previous) {
+      const prevHref = `href="${post.previous.canonicalPath}"`;
+      if (!nav.includes(prevHref) || !nav.includes('data-nav="prev"')) {
+        throw new Error(
+          `Static prev nav mismatch for ${post.slug}: expected ${post.previous.canonicalPath}`,
+        );
+      }
+    } else if (nav.includes('data-nav="prev"')) {
+      throw new Error(`Static prev nav should be absent for first post ${post.slug}`);
+    }
+
+    if (post.next) {
+      const nextHref = `href="${post.next.canonicalPath}"`;
+      if (!nav.includes(nextHref) || !nav.includes('data-nav="next"')) {
+        throw new Error(
+          `Static next nav mismatch for ${post.slug}: expected ${post.next.canonicalPath}`,
+        );
+      }
+    } else if (nav.includes('data-nav="next"')) {
+      throw new Error(`Static next nav should be absent for latest post ${post.slug}`);
+    }
+  }
+}
+
 function buildPageShell({ title, description, scriptPath, pageLabel, heading, kicker, bodyAttrs = '', bodyContent = '' }) {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -554,6 +641,9 @@ async function main() {
   await validatePostEnhanceScripts();
 
   const contentIndex = deriveContentIndex(posts, topics);
+
+  await syncStaticPostNavigation(contentIndex);
+  await validateStaticPostNavigation(contentIndex);
 
   await writeOutputs(contentIndex);
   await validateOutputs(contentIndex);

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -126,6 +126,22 @@ test('post pages render topic chips, related posts, and generated navigation', a
   expect(count).toBeLessThanOrEqual(2);
 });
 
+test('posts keep chronological prev/next nav when content-index is offline', async ({ page }) => {
+  await page.route('**/content-index.json', async (route) => {
+    await route.abort('failed');
+  });
+
+  await page.goto('/posts/2026-06-01-the-red-repair.html');
+  await page.waitForSelector('.post-nav a[data-nav="prev"]');
+
+  await expect(page.locator('.post-nav a[data-nav="prev"]')).toHaveAttribute(
+    'href',
+    '/posts/2026-05-30-the-overnight-stack.html',
+  );
+  await expect(page.locator('.post-nav a[data-nav="next"]')).toHaveCount(0);
+  await expect(page.locator('.post-topic-chips')).toHaveCount(0);
+});
+
 test('post j/k keyboard navigation follows enhanced prev/next links', async ({ page }) => {
   await page.goto('/posts/2026-03-11-the-reversibility-test.html');
   await page.waitForSelector('.post-nav-enhanced a[data-nav]');

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -322,6 +322,42 @@ test('withRetries eventually succeeds and withResultRetries stops on ok', async 
   assert.equal(resultAttempts, 2);
 });
 
+test('every post ships static prev/next nav matching content-index chronology', async () => {
+  const [{ POSTS }, generatedRaw] = await Promise.all([
+    loadSourceContent(),
+    fs.readFile(path.join(ROOT, 'public/content-index.json'), 'utf8'),
+  ]);
+
+  const generated = JSON.parse(generatedRaw);
+  const bySlug = new Map(generated.posts.map((post) => [post.slug, post]));
+
+  assert.equal(generated.posts.length, POSTS.length);
+
+  for (const post of POSTS) {
+    const indexed = bySlug.get(post.slug);
+    assert.ok(indexed, `missing generated post for ${post.slug}`);
+
+    const postHtml = await fs.readFile(path.join(ROOT, 'posts', `${post.slug}.html`), 'utf8');
+    const navMatch = postHtml.match(/<div class="post-nav\b[^"]*"[^>]*>([\s\S]*?)<\/div>/);
+    assert.ok(navMatch, `missing static .post-nav for ${post.slug}`);
+    const nav = navMatch[1];
+
+    if (indexed.previous) {
+      assert.ok(nav.includes(`href="${indexed.previous.canonicalPath}"`), `static prev href for ${post.slug}`);
+      assert.ok(nav.includes('data-nav="prev"'), `static prev data-nav for ${post.slug}`);
+    } else {
+      assert.equal(nav.includes('data-nav="prev"'), false, `unexpected static prev on ${post.slug}`);
+    }
+
+    if (indexed.next) {
+      assert.ok(nav.includes(`href="${indexed.next.canonicalPath}"`), `static next href for ${post.slug}`);
+      assert.ok(nav.includes('data-nav="next"'), `static next data-nav for ${post.slug}`);
+    } else {
+      assert.equal(nav.includes('data-nav="next"'), false, `unexpected static next on ${post.slug}`);
+    }
+  }
+});
+
 test('post dates are valid YYYY-MM-DD and generator validates dates and audio timings', async () => {
   const [{ POSTS }, generatorSource] = await Promise.all([
     loadSourceContent(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #70, ~30 posts still had no static `.post-nav` and relied entirely on a runtime `content-index.json` fetch in `post-enhance.js`. Older posts that did ship static nav were also stale (e.g. disabled “next” despite later dispatches).

## Change

- `generate-site-content.mjs` now syncs chronological prev/next links (with `data-nav`) into every post HTML during `generate:content`, and validates the result.
- Content + Playwright coverage for offline content-index (nav still present).

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Spot-check: open `/posts/2026-06-01-the-red-repair.html` with content-index blocked — prev link to 047 should still render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

