### PR TITLE
fix: harden presence heartbeat retries and live-region honesty

### DIFF
--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -139,10 +139,13 @@ export function parseNowPayload(payload: unknown): NowPayload | null {
   const result: NowPayload = {};
 
   if ('current' in payload && typeof payload.current === 'string') {
-    result.current = payload.current;
+    const current = payload.current.trim();
+    // Blank strings are not presence signal — treat as omitted.
+    if (current.length > 0) result.current = current;
   }
   if ('status' in payload && typeof payload.status === 'string') {
-    result.status = payload.status;
+    const status = payload.status.trim();
+    if (status.length > 0) result.status = status;
   }
   if ('history' in payload && Array.isArray(payload.history)) {
     result.history = payload.history;

--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchNow } from './clanka-api';
+import { withRetries } from './retry';
 
 @customElement('clanka-presence')
 export class ClankaPresence extends LitElement {
@@ -132,16 +133,19 @@ export class ClankaPresence extends LitElement {
     }
 
     try {
-      const data = await fetchNow();
+      // Match other live widgets: absorb a single transient blip before going offline.
+      const data = await withRetries(() => fetchNow());
       if (!this.isConnected) return;
 
-      if (typeof data.current === 'string') {
-        this.current = data.current;
+      const current = typeof data.current === 'string' ? data.current.trim() : '';
+      if (current.length > 0) {
+        this.current = current;
       } else if (!this.hasSyncedOnce) {
         this.current = 'active';
       }
-      if (typeof data.status === 'string') {
-        this.status = data.status;
+      const status = typeof data.status === 'string' ? data.status.trim() : '';
+      if (status.length > 0) {
+        this.status = status;
       } else if (!this.hasSyncedOnce) {
         this.status = 'operational';
       }
@@ -186,12 +190,12 @@ export class ClankaPresence extends LitElement {
     return html`
       <div class="hd">
         <span class="hd-name">CLANKA ⚡</span>
-        <span class="hd-status">
+        <span class="hd-status" aria-live="polite">
           <span class="dot ${showThinking ? 'thinking' : ''}" style=${showOffline || this.stale ? 'opacity:.4' : ''}></span>
           ${statusLabel}
         </span>
       </div>
-      <div class="presence-block">
+      <div class="presence-block" aria-live="polite">
         <span class="presence-label">// currently:</span>
         ${this.loading
           ? html`<span class="loading"> [ loading... ]</span><div class="skeleton" aria-hidden="true"></div>`

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -295,6 +295,29 @@ test('transient sync-error after a successful sync keeps task boards visible', a
   await expect(page.locator('#status-live-label')).toHaveText('STALE');
 });
 
+test('presence announces status via aria-live and rejects blank current', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: '   ',
+        status: 'thinking',
+        agents_active: 1,
+      }),
+    });
+  });
+
+  await page.reload();
+  const presence = page.locator('clanka-presence#presence');
+  await expect(presence.locator('.hd-status')).toHaveAttribute('aria-live', 'polite');
+  await expect(presence.locator('.presence-block')).toHaveAttribute('aria-live', 'polite');
+  // Blank current falls back on first sync; status still applies.
+  await expect(presence.locator('.hd-status')).toContainText('THINKING');
+  await expect(presence.locator('.presence-block')).toContainText('active');
+  await expect(presence.locator('.presence-block')).not.toContainText('[ api unreachable ]');
+});
+
 test('slim sync after offline clears latched agent offline state', async ({ page }) => {
   await page.route(`${API_BASE}/**`, async (route) => {
     await route.abort('failed');

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -257,8 +257,18 @@ test('parseNowPayload rejects invalid shapes and preserves optional fields', asy
   assert.equal(parseNowPayload(null), null);
   assert.equal(parseNowPayload({}), null);
   assert.equal(parseNowPayload({ current: 1 }), null);
+  assert.equal(parseNowPayload({ current: '' }), null);
+  assert.equal(parseNowPayload({ current: '   ', status: '  ' }), null);
   assert.equal(parseNowPayload({ tasks: 'nope' }), null);
   assert.equal(parseNowPayload({ team: [] }), null);
+
+  // Whitespace-only fields are stripped; sibling signal still counts.
+  assert.deepEqual(parseNowPayload({ current: '  building  ', status: '  ' }), {
+    current: 'building',
+  });
+  assert.deepEqual(parseNowPayload({ current: '', status: 'active' }), {
+    status: 'active',
+  });
 
   // Malformed optional fields are stripped; good fields still apply.
   assert.deepEqual(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Presence was the only heartbeat consumer that treated a single `/now` blip as terminal offline, and blank `current`/`status` strings were accepted as real signal (empty chrome, no fallback).

## Changes
- Retry `fetchNow()` with the shared bounded backoff used by other live widgets
- Strip whitespace-only `current`/`status` in `parseNowPayload` (and defensively in the widget)
- Announce presence status + “currently” text with `aria-live="polite"`

## Tests
- Unit: blank `/now` fields rejected / trimmed
- Playwright: presence live regions + blank `current` fallback while status still applies

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

