### PR TITLE
chore: enforce Node 24 via engines and engine-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ OPENAI_API_KEY=... python3 whisper_sync.py posts/<post>.html audio/<post>.mp3 <s
 
 ## Development
 
-Requires **Node.js 24+** (see `.nvmrc`). After cloning:
+Requires **Node.js 24** (see `.nvmrc`; `engines` is `^24` with `engine-strict`). After cloning:
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^22.19.18",
+        "@types/node": "^24.13.3",
         "typescript": "^5.9.2",
         "vite": "^8.0.16"
       },
       "engines": {
-        "node": ">=24"
+        "node": "^24.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -390,13 +390,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
-      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -939,9 +939,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=24"
+    "node": "^24.0.0"
   },
   "scripts": {
     "generate:content": "node scripts/generate-site-content.mjs",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/node": "^22.19.18",
+    "@types/node": "^24.13.3",
     "typescript": "^5.9.2",
     "vite": "^8.0.16"
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`engines.node` was `>=24` (allows untested majors), `@types/node` tracked Node 22, and npm did not enforce engines locally.

- Pin `engines.node` to `^24.0.0` to match `.nvmrc` and CI
- Add `.npmrc` with `engine-strict=true`
- Bump `@types/node` to `^24.13.3`
- Document the requirement in README

## Test plan
- [x] `npm run verify` (Node 24) passes locally
- [ ] CI green on this PR
- [ ] `npm ci` on Node 22 fails due to engine-strict (expected)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3def4ed4-87e0-43a0-a424-fd1bd291899a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3def4ed4-87e0-43a0-a424-fd1bd291899a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

