### PR TITLE
fix: validate github stats payloads before caching

### DIFF
--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -191,8 +191,44 @@ export async function fetchNow(): Promise<NowPayload> {
   return parsed;
 }
 
-export function fetchGithubStats(): Promise<unknown> {
-  return fetchJson('/github/stats');
+/** True when the payload has at least one well-typed stats field (zeros allowed). */
+export function isGithubStatsPayload(payload: unknown): boolean {
+  if (!isPlainObject(payload)) return false;
+
+  let recognized = false;
+
+  if ('repoCount' in payload) {
+    if (typeof payload.repoCount !== 'number' || !Number.isFinite(payload.repoCount) || payload.repoCount < 0) {
+      return false;
+    }
+    recognized = true;
+  }
+  if ('totalStars' in payload) {
+    if (typeof payload.totalStars !== 'number' || !Number.isFinite(payload.totalStars) || payload.totalStars < 0) {
+      return false;
+    }
+    recognized = true;
+  }
+  if ('lastPushedAt' in payload) {
+    if (typeof payload.lastPushedAt !== 'string') return false;
+    recognized = true;
+  }
+  if ('lastPushedRepo' in payload) {
+    if (typeof payload.lastPushedRepo !== 'string') return false;
+    recognized = true;
+  }
+
+  return recognized;
+}
+
+export async function fetchGithubStats(): Promise<unknown> {
+  const data = await fetchJson('/github/stats');
+  if (!isGithubStatsPayload(data)) {
+    // Don't TTL-cache `{ error: '…' }` / `{}` as a successful stats response.
+    invalidateEndpoint('/github/stats');
+    throw new Error('Invalid /github/stats payload');
+  }
+  return data;
 }
 
 /** True when the payload is a recognized fleet summary envelope (including empty). */

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -223,9 +223,12 @@ test('task display helpers normalize status and preserve labels', async () => {
 });
 
 test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
-  const { parseGithubEvents, isGithubEventsPayload, isFleetSummaryPayload } = await loadTsModule(
-    'src/clanka-api.ts',
-  );
+  const {
+    parseGithubEvents,
+    isGithubEventsPayload,
+    isFleetSummaryPayload,
+    isGithubStatsPayload,
+  } = await loadTsModule('src/clanka-api.ts');
   const sample = {
     type: 'PushEvent',
     repo: 'clankamode/site',
@@ -249,6 +252,13 @@ test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
   assert.equal(isFleetSummaryPayload({ summary: { repos: [] } }), true);
   assert.equal(isFleetSummaryPayload({ message: 'no registry' }), false);
   assert.equal(isFleetSummaryPayload(null), false);
+
+  assert.equal(isGithubStatsPayload({ repoCount: 0, totalStars: 0 }), true);
+  assert.equal(isGithubStatsPayload({ lastPushedAt: '2026-08-02T02:03:12Z', lastPushedRepo: 'site' }), true);
+  assert.equal(isGithubStatsPayload({ error: 'token expired' }), false);
+  assert.equal(isGithubStatsPayload({ repoCount: null }), false);
+  assert.equal(isGithubStatsPayload({}), false);
+  assert.equal(isGithubStatsPayload(null), false);
 });
 
 test('parseNowPayload rejects invalid shapes and preserves optional fields', async () => {
@@ -399,6 +409,39 @@ test('fetchNow invalidates cache after rejecting a malformed payload', async () 
     await assert.rejects(fetchNow(), /Invalid \/now payload/);
     const recovered = await fetchNow();
     assert.deepEqual(recovered, { current: 'recovered', status: 'active' });
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchGithubStats invalidates cache after rejecting a malformed payload', async () => {
+  const { fetchGithubStats } = await loadTsModule('src/clanka-api.ts');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return {
+        ok: true,
+        async json() {
+          return { error: 'token expired' };
+        },
+      };
+    }
+    return {
+      ok: true,
+      async json() {
+        return { repoCount: 8, totalStars: 0 };
+      },
+    };
+  };
+
+  try {
+    await assert.rejects(fetchGithubStats(), /Invalid \/github\/stats payload/);
+    const recovered = await fetchGithubStats();
+    assert.deepEqual(recovered, { repoCount: 8, totalStars: 0 });
     assert.equal(attempts, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -181,6 +181,23 @@ test('homepage repo stats show unavailable when live APIs fail', async ({ page }
   await expect(page.locator('#stat-fleet-score')).toHaveText('fleet: unavailable');
 });
 
+test('malformed github stats show unavailable instead of zeros', async ({ page }) => {
+  await page.route(`${API_BASE}/github/stats`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'token expired', repoCount: null, totalStars: null }),
+    });
+  });
+
+  await page.reload();
+  await expect(page.locator('#stat-repos')).toHaveText('repos unavailable');
+  await expect(page.locator('#stat-stars')).toHaveText('stars unavailable');
+  await expect(page.locator('#stat-last-commit')).toHaveText('last push: unavailable');
+  // Fleet is independent — still hydrated from the default mock.
+  await expect(page.locator('#stat-fleet-score')).toHaveText('fleet: 42 repos');
+});
+
 test('slim initial /now without agent count clears agents placeholder', async ({ page }) => {
   await page.route(`${API_BASE}/now`, async (route) => {
     await route.fulfill({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/github/stats` was the last live endpoint that TTL-cached arbitrary 200 JSON. Error objects and empty `{}` responses were treated as successful fetches, so retries hit cache and hero stats could not recover until TTL expired.

## Changes
- Add `isGithubStatsPayload` — requires at least one well-typed stats field (`repoCount` / `totalStars` / `lastPushedAt` / `lastPushedRepo`); real zeros remain valid
- `fetchGithubStats` invalidates the shared cache and throws on bad shapes (same pattern as `/now` and `/fleet/summary`)

## Tests
- Unit: shape checks + cache invalidation recovery
- Playwright: malformed stats → `unavailable`, not stuck placeholders; fleet remains independent

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

