### PR TITLE
fix(a11y): improve 404 recovery links and requested-path echo

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#070708" />
+  <meta name="robots" content="noindex" />
   <meta name="description" content="Page not found — CLANKA" />
   <meta property="og:title" content="404 — CLANKA" />
   <meta property="og:description" content="No dispatch at this path." />
@@ -25,6 +26,15 @@
       --font-mono: 'IBM Plex Mono', 'Courier New', Courier, monospace;
       --font-display: 'Space Mono', 'IBM Plex Mono', monospace;
     }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f4f6f8;
+        --text: #223042;
+        --dim: #455062;
+        --accent: #3f7f19;
+        --border: #d4d9df;
+      }
+    }
     * { box-sizing: border-box; }
     body {
       margin: 0;
@@ -37,6 +47,13 @@
       color: var(--text);
       font-family: var(--font-mono);
       padding: 24px;
+    }
+    @media (prefers-color-scheme: light) {
+      body {
+        background:
+          radial-gradient(ellipse at top, rgba(63, 127, 25, 0.12), transparent 55%),
+          var(--bg);
+      }
     }
     main {
       max-width: 28rem;
@@ -58,7 +75,19 @@
     p {
       color: var(--dim);
       line-height: 1.6;
+      margin: 0 0 16px;
+    }
+    .path-line {
       margin: 0 0 28px;
+      font-size: 12px;
+      word-break: break-all;
+    }
+    .path-line[hidden] {
+      display: none;
+    }
+    .path-line code {
+      color: var(--text);
+      font-family: var(--font-mono);
     }
     nav {
       display: flex;
@@ -75,18 +104,43 @@
       font-size: 13px;
     }
     a:hover { color: var(--accent); border-color: var(--accent); }
+    a:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 3px;
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+    }
   </style>
 </head>
 <body>
-  <main>
+  <main id="main-content">
     <p class="kicker">// not found</p>
     <h1>404</h1>
     <p>No dispatch at this path. The link may be stale, mistyped, or never existed.</p>
+    <p class="path-line" id="path-line" hidden>
+      Requested path: <code id="requested-path"></code>
+    </p>
     <nav aria-label="Recovery links">
       <a href="/">home</a>
       <a href="/logs/">archive</a>
       <a href="/now.html">now</a>
+      <a href="/feed.xml">rss</a>
     </nav>
   </main>
+  <script>
+    (() => {
+      const path = `${location.pathname}${location.search}`;
+      const el = document.getElementById('requested-path');
+      const line = document.getElementById('path-line');
+      if (!el || !line) return;
+      // Direct visits to the 404 document itself are not a missing route.
+      if (path === '/404.html' || path === '/404') return;
+      el.textContent = path;
+      line.hidden = false;
+    })();
+  </script>
 </body>
 </html>

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -149,8 +149,30 @@ test('404 page is a dedicated not-found shell', async ({ page }) => {
   await expect(page.locator('h1')).toHaveText('404');
   await expect(page.locator('main')).toContainText('No dispatch at this path');
   await expect(page.locator('body')).not.toContainText('I build systems');
+  await expect(page.locator('#path-line')).toBeHidden();
   await expect(page.getByRole('link', { name: 'home' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'archive' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'now' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'rss' })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex');
+});
+
+test('404 page surfaces the requested path for missing routes', async ({ page }) => {
+  // Mimic GitHub Pages: serve the 404 document at the missing URL so the
+  // inline script can echo location.pathname.
+  await page.route('**/missing-dispatch**', async (route) => {
+    const response = await route.fetch({ url: 'http://127.0.0.1:8080/404.html' });
+    await route.fulfill({
+      status: 404,
+      contentType: 'text/html',
+      body: await response.text(),
+    });
+  });
+
+  await page.goto('/missing-dispatch/?from=test');
+  await expect(page.locator('h1')).toHaveText('404');
+  await expect(page.locator('#path-line')).toBeVisible();
+  await expect(page.locator('#requested-path')).toHaveText('/missing-dispatch/?from=test');
 });
 
 test('archive status bar does not claim LIVE telemetry', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Echo the requested path on missing routes (hidden for direct `/404.html` visits).
- Add `focus-visible` styles, light `prefers-color-scheme` contrast tokens, `noindex`, and an RSS recovery link.
- Keep the existing quiet 404 composition — no redesign, just clearer recovery affordances.

## Test plan
- [x] `npm run verify` (Node 24)
- [x] Playwright: dedicated 404 shell + path echo for a missing URL
- [ ] Manual: Tab through recovery links and confirm focus rings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f544ca-5786-4bfc-b079-c132c6e24596?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f544ca-5786-4bfc-b079-c132c6e24596&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

