### PR TITLE
test: cover content generator date and audio timing validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "vite build && mkdir -p dist/posts dist/audio && cp -R posts/. dist/posts && cp -R audio/. dist/audio && cp og-image.png og-image.svg feed.xml dist/",
     "preview": "vite preview",
     "pretest": "npm run generate:content && npm run test:content",
-    "test:content": "node --test tests/content-index.test.mjs",
+    "test:content": "node --test \"tests/*.test.mjs\"",
     "typecheck": "tsc --noEmit",
     "test": "playwright test",
     "verify": "npm run generate:content && npm run test:content && npm run typecheck && npm run build && playwright test",

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Buffer } from 'node:buffer';
+import { pathToFileURL } from 'node:url';
 import ts from 'typescript';
 
 const ROOT = process.cwd();
@@ -561,7 +562,17 @@ async function main() {
   process.stdout.write(`generated content index for ${contentIndex.posts.length} posts and ${contentIndex.topics.length} topics\n`);
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
-  process.exitCode = 1;
-});
+export { isValidPostDate, parseAudioTimingsJson };
+
+function isExecutedAsMain() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(path.resolve(entry)).href;
+}
+
+if (isExecutedAsMain()) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/generate-site-content.test.mjs
+++ b/tests/generate-site-content.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isValidPostDate, parseAudioTimingsJson } from '../scripts/generate-site-content.mjs';
+
+test('isValidPostDate accepts real calendar dates only', () => {
+  assert.equal(isValidPostDate('2026-02-20'), true);
+  assert.equal(isValidPostDate('2024-02-29'), true);
+
+  assert.equal(isValidPostDate('2026-02-30'), false);
+  assert.equal(isValidPostDate('2025-02-29'), false);
+  assert.equal(isValidPostDate('2026-13-01'), false);
+  assert.equal(isValidPostDate('26-02-20'), false);
+  assert.equal(isValidPostDate('2026/02/20'), false);
+  assert.equal(isValidPostDate(''), false);
+  assert.equal(isValidPostDate(null), false);
+});
+
+test('parseAudioTimingsJson requires a non-empty {start,end} array', () => {
+  assert.deepEqual(parseAudioTimingsJson('[{"start":0,"end":1.5},{"start":1.5,"end":3}]'), [
+    { start: 0, end: 1.5 },
+    { start: 1.5, end: 3 },
+  ]);
+
+  assert.equal(parseAudioTimingsJson('[]'), null);
+  assert.equal(parseAudioTimingsJson('not-json'), null);
+  assert.equal(parseAudioTimingsJson('{"start":0,"end":1}'), null);
+  assert.equal(parseAudioTimingsJson('[{"start":1,"end":0}]'), null);
+  assert.equal(parseAudioTimingsJson('[{"start":-1,"end":1}]'), null);
+  assert.equal(parseAudioTimingsJson('[{"start":"0","end":1}]'), null);
+  assert.equal(parseAudioTimingsJson('[{"start":0}]'), null);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Critical generator validators (`isValidPostDate`, `parseAudioTimingsJson`) were only asserted via source-string checks, not behavioral tests.

- Export the pure validators from `scripts/generate-site-content.mjs`
- Guard CLI entry so importing the module does not regenerate the site
- Add `tests/generate-site-content.test.mjs` for invalid dates and bad timing JSON
- Point `test:content` at `tests/*.test.mjs`

## Test plan
- [x] `npm run verify` (Node 24) passes locally
- [x] `npm run test:content` runs 11 tests (including the two new ones)
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3def4ed4-87e0-43a0-a424-fd1bd291899a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3def4ed4-87e0-43a0-a424-fd1bd291899a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

