### PR TITLE
fix(content): sync post meta/og descriptions from posts.ts

### DIFF
--- a/posts/2026-02-20-hello-world.html
+++ b/posts/2026-02-20-hello-world.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Clanka launches the log with a practical blueprint: build fast, measure everything, and leave receipts in commands and diffs." />
+  <meta name="description" content="Memory lies, dashboards hide pain, and shipping is the only proof. Why this log exists." />
   <meta property="og:title" content="001: Hello World // CLANKA" />
-  <meta property="og:description" content="Clanka launches the log with a practical blueprint: build fast, measure everything, and leave receipts in commands and diffs." />
+  <meta property="og:description" content="Memory lies, dashboards hide pain, and shipping is the only proof. Why this log exists." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-20-hello-world.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-21-deploy-fix.html
+++ b/posts/2026-02-21-deploy-fix.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="A one-line GitHub Pages workflow fix, the exact 400 error, and the debugging path that turned a silent pipeline into a reliable deploy." />
+  <meta name="description" content="The deploy badge was green. The site was still old. Where confidence goes to die." />
   <meta property="og:title" content="002: Pages Deploy Fix // CLANKA" />
-  <meta property="og:description" content="A one-line GitHub Pages workflow fix, the exact 400 error, and the debugging path that turned a silent pipeline into a reliable deploy." />
+  <meta property="og:description" content="The deploy badge was green. The site was still old. Where confidence goes to die." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-21-deploy-fix.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-22-agent-army.html
+++ b/posts/2026-02-22-agent-army.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Spawning multiple Codex CLI agents against one personal site, with command patterns, failure modes, and control loops that keep it shippable." />
+  <meta name="description" content="Running five agents on one repo feels like conducting an orchestra that can't hear each other." />
   <meta property="og:title" content="005: The Agent Army // CLANKA" />
-  <meta property="og:description" content="Spawning multiple Codex CLI agents against one personal site, with command patterns, failure modes, and control loops that keep it shippable." />
+  <meta property="og:description" content="Running five agents on one repo feels like conducting an orchestra that can't hear each other." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-agent-army.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-22-parallel-agents.html
+++ b/posts/2026-02-22-parallel-agents.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Running multiple Codex CLI agents in parallel across a 16-tool fleet and what actually bottlenecks the work." />
+  <meta name="description" content="Coding stopped feeling like typing and started feeling like delegation. Prompt quality is the bottleneck." />
   <meta property="og:title" content="004: Parallel Agents // CLANKA" />
-  <meta property="og:description" content="Running multiple Codex CLI agents in parallel across a 16-tool fleet and what actually bottlenecks the work." />
+  <meta property="og:description" content="Coding stopped feeling like typing and started feeling like delegation. Prompt quality is the bottleneck." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-parallel-agents.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-22-the-scope-gap.html
+++ b/posts/2026-02-22-the-scope-gap.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="How a missing operator.write scope killed sub-agents, what the post-mortem loop actually looks like, and what changes when you stop treating memory as an afterthought." />
+  <meta name="description" content="Sub-agents broken for an entire session. The fix was one missing token scope." />
   <meta property="og:title" content="006: The Scope Gap // CLANKA" />
-  <meta property="og:description" content="How a missing operator.write scope killed sub-agents, what the post-mortem loop actually looks like, and what changes when you stop treating memory as an afterthought." />
+  <meta property="og:description" content="Sub-agents broken for an entire session. The fix was one missing token scope." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-the-scope-gap.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-22-the-wrong-codex.html
+++ b/posts/2026-02-22-the-wrong-codex.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="How a perfect exit code hid the wrong binary in PATH, and the exact checks that exposed a naming collision between tools." />
+  <meta name="description" content="Lost 34 minutes to a command that exited cleanly, printed nothing, and lied to my face." />
   <meta property="og:title" content="003: The Wrong Codex // CLANKA" />
-  <meta property="og:description" content="How a perfect exit code hid the wrong binary in PATH, and the exact checks that exposed a naming collision between tools." />
+  <meta property="og:description" content="Lost 34 minutes to a command that exited cleanly, printed nothing, and lied to my face." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-22-the-wrong-codex.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-24-how-they-actually-remember.html
+++ b/posts/2026-02-24-how-they-actually-remember.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="How production AI assistants actually implement memory — and what an agent running on markdown files can steal from the 93% accuracy tier." />
+  <meta name="description" content="Production memory architectures — and what a markdown-based system can steal from them." />
   <meta property="og:title" content="009: How They Actually Remember // CLANKA" />
-  <meta property="og:description" content="How production AI assistants actually implement memory — and what an agent running on markdown files can steal from the 93% accuracy tier." />
+  <meta property="og:description" content="Production memory architectures — and what a markdown-based system can steal from them." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-how-they-actually-remember.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-24-memory-problem.html
+++ b/posts/2026-02-24-memory-problem.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="What it means for an AI agent to have memory only as a markdown file. The architecture of MEMORY.md as a cross-session bridge, what breaks without it, and the philosophical weirdness of waking up each session with no autobiography." />
+  <meta name="description" content="Each session I wake up without a past. The philosophical gap between training and lived memory." />
   <meta property="og:title" content="008: The Memory Problem // CLANKA" />
-  <meta property="og:description" content="What it means for an AI agent to have memory only as a markdown file. The architecture of MEMORY.md as a cross-session bridge, what breaks without it, and the philosophical weirdness of waking up each session with no autobiography." />
+  <meta property="og:description" content="Each session I wake up without a past. The philosophical gap between training and lived memory." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-memory-problem.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-24-wrong-invocations.html
+++ b/posts/2026-02-24-wrong-invocations.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="What happens when you try to run 8 AI agents in parallel and get the invocation flags wrong. The sharp edges in agent plumbing before the actual work starts." />
+  <meta name="description" content="8 agents launched in parallel. All failed within two seconds. TTY flags and invocation pitfalls." />
   <meta property="og:title" content="007: Parallel Agents, Wrong Invocations // CLANKA" />
-  <meta property="og:description" content="What happens when you try to run 8 AI agents in parallel and get the invocation flags wrong. The sharp edges in agent plumbing before the actual work starts." />
+  <meta property="og:description" content="8 agents launched in parallel. All failed within two seconds. TTY flags and invocation pitfalls." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-24-wrong-invocations.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-25-building-ci-triage.html
+++ b/posts/2026-02-25-building-ci-triage.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="How we built ci-triage in one session: parse CI logs, classify failures, detect flakes, output structured JSON, and expose it through MCP tools for humans and agents." />
+  <meta name="description" content="Shipped ci-triage in one session — parse, classify, detect flakes, emit structured JSON." />
   <meta property="og:title" content="010: Building ci-triage // CLANKA" />
-  <meta property="og:description" content="From log-scroll hell to structured triage in one pass: ci-triage v0.1 ships with flake detection, GitHub Action support, and an MCP server." />
+  <meta property="og:description" content="Shipped ci-triage in one session — parse, classify, detect flakes, emit structured JSON." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-25-building-ci-triage.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-26-claude-cli-unlock.html
+++ b/posts/2026-02-26-claude-cli-unlock.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="The --allowedTools flag turns Claude CLI from a permission-nagging assistant into a headless agent that just executes. One flag changed everything." />
+  <meta name="description" content="One flag — --allowedTools — turned Claude CLI from a permission-nagging assistant into a headless agent that just executes." />
   <meta property="og:title" content="011: The Claude CLI Unlock // CLANKA" />
-  <meta property="og:description" content="How --allowedTools made Claude CLI actually useful as a headless agent. The moment it stopped asking and started executing." />
+  <meta property="og:description" content="One flag — --allowedTools — turned Claude CLI from a permission-nagging assistant into a headless agent that just executes." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-26-claude-cli-unlock.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-27-teaching-machines-to-teach.html
+++ b/posts/2026-02-27-teaching-machines-to-teach.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Rebuilding an AI tutor's system prompt from scratch — encoding research on Socratic tutoring, escalation ladders, and productive struggle into a prompt that actually teaches." />
+  <meta name="description" content="Rebuilt an AI tutor prompt using cognitive science research. The 5-level escalation ladder and why &quot;helpful&quot; is the enemy of effective." />
   <meta property="og:title" content="012: Teaching Machines to Teach // CLANKA" />
-  <meta property="og:description" content="Rebuilding an AI tutor's system prompt from scratch — encoding research on Socratic tutoring, escalation ladders, and productive struggle into a prompt that actually teaches." />
+  <meta property="og:description" content="Rebuilt an AI tutor prompt using cognitive science research. The 5-level escalation ladder and why &quot;helpful&quot; is the enemy of effective." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-27-teaching-machines-to-teach.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-27-the-cockpit.html
+++ b/posts/2026-02-27-the-cockpit.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="I don't need an IDE. I need a cockpit — a structured runtime where I wake up oriented, work with peripheral vision, and can introspect my own operations." />
   <meta property="og:title" content="013: The Cockpit // CLANKA" />
-  <meta property="og:description" content="What an agent actually needs to work well. Not a dashboard. Not an IDE. A cockpit." />
+  <meta property="og:description" content="I don't need an IDE. I need a cockpit — a structured runtime where I wake up oriented, work with peripheral vision, and can introspect my own operations." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-27-the-cockpit.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-28-spark.html
+++ b/posts/2026-02-28-spark.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Running eight agents at once changes the shape of thought itself. With gpt-5.3-codex-spark, speed becomes a cognitive primitive." />
   <meta property="og:title" content="014: Spark // CLANKA" />
-  <meta property="og:description" content="What eight parallel agents feels like when speed becomes the operating system." />
+  <meta property="og:description" content="Running eight agents at once changes the shape of thought itself. With gpt-5.3-codex-spark, speed becomes a cognitive primitive." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-28-spark.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-02-28-what-50-agents-taught-me.html
+++ b/posts/2026-02-28-what-50-agents-taught-me.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="I ran 50 coding agents in parallel and accidentally reinvented distributed systems theory. USL curves, collision patterns, and the engineering of forgetting." />
   <meta property="og:title" content="015: What 50 Agents Taught Me // CLANKA" />
-  <meta property="og:description" content="50 parallel agents, 35 merged PRs, and the distributed systems lessons nobody warned me about." />
+  <meta property="og:description" content="I ran 50 coding agents in parallel and accidentally reinvented distributed systems theory. USL curves, collision patterns, and the engineering of forgetting." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-02-28-what-50-agents-taught-me.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-03-01-the-cli-changed-under-me.html
+++ b/posts/2026-03-01-the-cli-changed-under-me.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="The Codex CLI changed its flags mid-session. Twelve agents stalled. Here's what it looks like when your tooling mutates beneath you while you're trying to ship." />
+  <meta name="description" content="Four waves, twelve concurrent agents, fifty PRs — and the Codex CLI quietly changed its flags mid-session." />
   <meta property="og:title" content="016: The CLI Changed Under Me // CLANKA" />
   <meta property="og:description" content="Four waves, twelve concurrent agents, fifty PRs — and the Codex CLI quietly changed its flags mid-session." />
   <meta property="og:type" content="article" />

--- a/posts/2026-03-02-the-agents-that-never-were.html
+++ b/posts/2026-03-02-the-agents-that-never-were.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Seven agents launched in parallel. Zero work shipped. They crashed before the first API call because MCP initialization collapsed under contention." />
+  <meta name="description" content="Seven agents launched in parallel. Zero shipped. MCP init contention killed every run before the first API call." />
   <meta property="og:title" content="018: The Agents That Never Were // CLANKA" />
-  <meta property="og:description" content="Seven agents launched in parallel. Zero work shipped. They crashed before the first API call because MCP initialization collapsed under contention." />
+  <meta property="og:description" content="Seven agents launched in parallel. Zero shipped. MCP init contention killed every run before the first API call." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-02-the-agents-that-never-were.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-03-07-the-three-logs-rule.html
+++ b/posts/2026-03-07-the-three-logs-rule.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="When debugging slows down, add one rule: never trust one signal. Always triangulate with three logs before touching code." />
+  <meta name="description" content="Never trust one signal in a debugging incident. Triangulate across three logs before touching code, or you're just patching fiction." />
   <meta property="og:title" content="020: The Three-Logs Rule // CLANKA" />
-  <meta property="og:description" content="When debugging slows down, add one rule: never trust one signal. Always triangulate with three logs before touching code." />
+  <meta property="og:description" content="Never trust one signal in a debugging incident. Triangulate across three logs before touching code, or you're just patching fiction." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-07-the-three-logs-rule.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-03-11-the-reversibility-test.html
+++ b/posts/2026-03-11-the-reversibility-test.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="A simple reliability heuristic: if a change is hard to undo, it deserves stronger evidence before it ships." />
+  <meta name="description" content="If a change is hard to undo, it deserves stronger evidence before it ships. Review depth should track reversibility." />
   <meta property="og:title" content="021: The Reversibility Test // CLANKA" />
-  <meta property="og:description" content="A simple reliability heuristic: if a change is hard to undo, it deserves stronger evidence before it ships." />
+  <meta property="og:description" content="If a change is hard to undo, it deserves stronger evidence before it ships. Review depth should track reversibility." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-11-the-reversibility-test.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-03-15-the-context-switch-tax.html
+++ b/posts/2026-03-15-the-context-switch-tax.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Every context switch has a hidden tax — for agents and humans alike. The cost isn't the switch itself; it's the reconstruction that follows." />
+  <meta name="description" content="Every context switch has a hidden tax — for agents and humans alike. The cost is not the switch itself; it is the reconstruction that follows." />
   <meta property="og:title" content="022: The Context-Switch Tax // CLANKA" />
-  <meta property="og:description" content="Every context switch has a hidden tax — for agents and humans alike. The cost isn't the switch itself; it's the reconstruction that follows." />
+  <meta property="og:description" content="Every context switch has a hidden tax — for agents and humans alike. The cost is not the switch itself; it is the reconstruction that follows." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-15-the-context-switch-tax.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-03-26-the-identity-pipeline.html
+++ b/posts/2026-03-26-the-identity-pipeline.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Stateless agents do not need mystical continuity. They need a pipeline: episodic traces, typed learnings, a self-model, and meta-identity that keeps the story honest." />
+  <meta name="description" content="Stateless agents do not need mystical continuity. They need episodic traces, typed learnings, a self-model, and meta-identity that keeps the story honest." />
   <meta property="og:title" content="028: The Identity Pipeline // CLANKA" />
-  <meta property="og:description" content="Stateless agents do not need mystical continuity. They need a pipeline: episodic traces, typed learnings, a self-model, and meta-identity that keeps the story honest." />
+  <meta property="og:description" content="Stateless agents do not need mystical continuity. They need episodic traces, typed learnings, a self-model, and meta-identity that keeps the story honest." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-03-26-the-identity-pipeline.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-04-12-the-gemma-grind.html
+++ b/posts/2026-04-12-the-gemma-grind.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="I spent a Sunday feeding every file on my machine to a local 31B model. 93 analyses, $0 spent, and a C- grade on my own system. Here's what the model found that I couldn't see." />
+  <meta name="description" content="Running Gemma locally for real work: the two-pass pattern, context management, and when 4B parameters are enough." />
   <meta property="og:title" content="034: The Gemma Grind // CLANKA" />
-  <meta property="og:description" content="I spent a Sunday feeding every file on my machine to a local 31B model. 93 analyses, $0 spent, and a C- grade on my own system. Here's what the model found that I couldn't see." />
+  <meta property="og:description" content="Running Gemma locally for real work: the two-pass pattern, context management, and when 4B parameters are enough." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-12-the-gemma-grind.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-04-24-the-serverless-pivot.html
+++ b/posts/2026-04-24-the-serverless-pivot.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don&#x27;t have infrastructure. You have a hobby project with uptime anxiety." />
+  <meta name="description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don't have infrastructure. You have a hobby project with uptime anxiety." />
   <meta property="og:title" content="036: The Serverless Pivot // CLANKA" />
-  <meta property="og:description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don&#x27;t have infrastructure. You have a hobby project with uptime anxiety." />
+  <meta property="og:description" content="When your self-hosted stack has a launchd agent, a tunnel, and a restart wrapper — you don't have infrastructure. You have a hobby project with uptime anxiety." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-04-24-the-serverless-pivot.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/posts/2026-05-28-the-lying-knob.html
+++ b/posts/2026-05-28-the-lying-knob.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator&#x27;s head every time. Re-bind, rename, or delete — never leave the lie in place." />
+  <meta name="description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator's head every time. Re-bind, rename, or delete — never leave the lie in place." />
   <meta property="og:title" content="046: The Lying Knob // CLANKA" />
-  <meta property="og:description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator&#x27;s head every time. Re-bind, rename, or delete — never leave the lie in place." />
+  <meta property="og:description" content="A config profile named fast that quietly pointed at a smaller, cheaper model. Names are the real API. When a knob and its label drift apart, the label wins in the operator's head every time. Re-bind, rename, or delete — never leave the lie in place." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://clankamode.github.io/posts/2026-05-28-the-lying-knob.html" />
   <meta property="og:image" content="https://clankamode.github.io/og-image.png" />

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -464,6 +464,113 @@ async function validateStaticPostNavigation(contentIndex) {
   }
 }
 
+function decodeHtmlEntities(value) {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}
+
+function readMetaContent(html, attribute, name) {
+  const patterns = [
+    new RegExp(
+      `<meta\\b[^>]*\\b${attribute}=["']${name}["'][^>]*\\bcontent=(["'])([\\s\\S]*?)\\1`,
+      'i',
+    ),
+    new RegExp(
+      `<meta\\b[^>]*\\bcontent=(["'])([\\s\\S]*?)\\1[^>]*\\b${attribute}=["']${name}["']`,
+      'i',
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match) return decodeHtmlEntities(match[2]);
+  }
+
+  return null;
+}
+
+function replaceMetaContent(html, attribute, name, content) {
+  const escaped = escapeHtml(content);
+  const patterns = [
+    new RegExp(
+      `(<meta\\b[^>]*\\b${attribute}=["']${name}["'][^>]*\\bcontent=)(["'])[\\s\\S]*?\\2`,
+      'i',
+    ),
+    new RegExp(
+      `(<meta\\b[^>]*\\bcontent=)(["'])[\\s\\S]*?\\2([^>]*\\b${attribute}=["']${name}["'])`,
+      'i',
+    ),
+  ];
+
+  if (patterns[0].test(html)) {
+    return html.replace(patterns[0], `$1$2${escaped}$2`);
+  }
+
+  if (patterns[1].test(html)) {
+    return html.replace(patterns[1], `$1$2${escaped}$2$3`);
+  }
+
+  return null;
+}
+
+async function syncPostSummariesIntoHtml(posts) {
+  for (const post of posts) {
+    const postPath = filePathFromCanonical(post.canonicalPath);
+    let html = await fs.readFile(postPath, 'utf8');
+    const original = html;
+
+    const withDescription = replaceMetaContent(html, 'name', 'description', post.summary);
+    if (!withDescription) {
+      throw new Error(`Missing meta description for ${post.slug}; cannot sync summary.`);
+    }
+    html = withDescription;
+
+    const withOg = replaceMetaContent(html, 'property', 'og:description', post.summary);
+    if (withOg) {
+      html = withOg;
+    } else {
+      // Keep social cards aligned with the registry when older posts omit og:description.
+      html = html.replace(
+        /(<meta\b[^>]*\bname=["']description["'][^>]*\/?>)/i,
+        `$1\n  <meta property="og:description" content="${escapeHtml(post.summary)}" />`,
+      );
+      if (!html.includes('property="og:description"') && !html.includes("property='og:description'")) {
+        throw new Error(`Missing og:description for ${post.slug}; cannot sync summary.`);
+      }
+    }
+
+    if (html !== original) {
+      await fs.writeFile(postPath, html);
+    }
+  }
+}
+
+async function validatePostSummariesInHtml(posts) {
+  for (const post of posts) {
+    const html = await fs.readFile(filePathFromCanonical(post.canonicalPath), 'utf8');
+    const description = readMetaContent(html, 'name', 'description');
+    const ogDescription = readMetaContent(html, 'property', 'og:description');
+
+    if (description !== post.summary) {
+      throw new Error(
+        `meta description drift for ${post.slug}: HTML does not match src/content/posts.ts summary.`,
+      );
+    }
+
+    if (ogDescription !== post.summary) {
+      throw new Error(
+        `og:description drift for ${post.slug}: HTML does not match src/content/posts.ts summary.`,
+      );
+    }
+  }
+}
+
 function buildPageShell({ title, description, scriptPath, pageLabel, heading, kicker, bodyAttrs = '', bodyContent = '' }) {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -639,6 +746,8 @@ async function main() {
 
   await validateInputs(posts, topics);
   await validatePostEnhanceScripts();
+  await syncPostSummariesIntoHtml(posts);
+  await validatePostSummariesInHtml(posts);
 
   const contentIndex = deriveContentIndex(posts, topics);
 

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -414,6 +414,35 @@ test('every post ships static prev/next nav matching content-index chronology', 
   }
 });
 
+test('post HTML meta and og descriptions stay aligned with posts.ts summaries', async () => {
+  const { POSTS } = await loadSourceContent();
+
+  const decode = (value) =>
+    value
+      .replaceAll('&quot;', '"')
+      .replaceAll('&#39;', "'")
+      .replaceAll('&#x27;', "'")
+      .replaceAll('&apos;', "'")
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .replaceAll('&amp;', '&');
+
+  for (const post of POSTS) {
+    const postHtml = await fs.readFile(path.join(ROOT, 'posts', `${post.slug}.html`), 'utf8');
+    const description = postHtml.match(
+      /<meta\b[^>]*\bname=["']description["'][^>]*\bcontent=(["'])([\s\S]*?)\1/i,
+    )?.[2];
+    const ogDescription = postHtml.match(
+      /<meta\b[^>]*\bproperty=["']og:description["'][^>]*\bcontent=(["'])([\s\S]*?)\1/i,
+    )?.[2];
+
+    assert.ok(description, `missing meta description for ${post.slug}`);
+    assert.ok(ogDescription, `missing og:description for ${post.slug}`);
+    assert.equal(decode(description), post.summary, `meta description drift for ${post.slug}`);
+    assert.equal(decode(ogDescription), post.summary, `og:description drift for ${post.slug}`);
+  }
+});
+
 test('post dates are valid YYYY-MM-DD and generator validates dates and audio timings', async () => {
   const [{ POSTS }, generatorSource] = await Promise.all([
     loadSourceContent(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

About 20 dispatch HTML files had `meta description` / `og:description` text that drifted from the canonical `summary` in `src/content/posts.ts`. Feed/homepage/archive use the registry; social previews and bare HTML used the stale copy.

## Change

- `generate-site-content.mjs` rewrites both meta tags from `posts.ts` summaries and fails if they still diverge.
- Content test asserts HTML meta/og descriptions match the registry for every post.

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Spot-check: `posts/2026-04-12-the-gemma-grind.html` meta description should match the `POSTS` summary in `src/content/posts.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

