### PR TITLE
fix: treat unusable github event lists as unavailable

### DIFF
--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -74,10 +74,31 @@ function isGithubEvent(value: unknown): value is GithubEvent {
   const event = value as Partial<GithubEvent>;
   return (
     typeof event.type === 'string' &&
+    event.type.trim().length > 0 &&
     typeof event.repo === 'string' &&
+    event.repo.trim().length > 0 &&
     typeof event.message === 'string' &&
-    typeof event.timestamp === 'string'
+    typeof event.timestamp === 'string' &&
+    event.timestamp.trim().length > 0
   );
+}
+
+function rawGithubEventArray(payload: unknown): unknown[] | null {
+  if (Array.isArray(payload)) return payload;
+  if (isPlainObject(payload) && Array.isArray(payload.events)) return payload.events;
+  return null;
+}
+
+function dedupeGithubEvents(events: GithubEvent[]): GithubEvent[] {
+  const seen = new Set<string>();
+  const out: GithubEvent[] = [];
+  for (const event of events) {
+    const key = `${event.type}\0${event.repo}\0${event.message}\0${event.timestamp}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(event);
+  }
+  return out;
 }
 
 /** True when the payload is a recognized events envelope (including empty). */
@@ -89,16 +110,9 @@ export function isGithubEventsPayload(payload: unknown): boolean {
 
 /** Accepts both `{ events: [...] }` and bare array payloads from clanka-api. */
 export function parseGithubEvents(payload: unknown): GithubEvent[] {
-  if (Array.isArray(payload)) {
-    return payload.filter(isGithubEvent);
-  }
-
-  if (payload && typeof payload === 'object' && 'events' in payload) {
-    const events = (payload as { events: unknown }).events;
-    return Array.isArray(events) ? events.filter(isGithubEvent) : [];
-  }
-
-  return [];
+  const raw = rawGithubEventArray(payload);
+  if (!raw) return [];
+  return dedupeGithubEvents(raw.filter(isGithubEvent));
 }
 
 export type GithubEventsResult =
@@ -113,7 +127,16 @@ export async function fetchGithubEvents(): Promise<GithubEventsResult> {
       invalidateEndpoint('/github/events');
       return { ok: false, reason: 'offline' };
     }
-    return { ok: true, events: parseGithubEvents(data) };
+
+    const raw = rawGithubEventArray(data) ?? [];
+    const events = parseGithubEvents(data);
+    // Entries present but none parseable → unavailable, not a honest empty feed.
+    if (raw.length > 0 && events.length === 0) {
+      invalidateEndpoint('/github/events');
+      return { ok: false, reason: 'offline' };
+    }
+
+    return { ok: true, events };
   } catch {
     return { ok: false, reason: 'offline' };
   }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -206,6 +206,32 @@ test('malformed github events show unavailable instead of empty activity', async
   );
 });
 
+test('all-invalid github event items show unavailable instead of empty activity', async ({ page }) => {
+  await page.route(`${API_BASE}/github/events`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        events: [
+          { type: 'PUSH', repo: '', message: 'push', timestamp: '2026-08-06T23:07:47Z' },
+          { foo: 'bar' },
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  await page.locator('#commit-feed').scrollIntoViewIfNeeded();
+  await expect(page.locator('#commit-feed')).toContainText('// activity unavailable');
+  await expect(page.locator('#commit-feed')).not.toContainText('// no recent activity');
+
+  await page.locator('clanka-terminal#terminal').scrollIntoViewIfNeeded();
+  await expect(page.locator('clanka-terminal#terminal')).toContainText(
+    '[ offline — activity unavailable ]',
+  );
+  await expect(page.locator('clanka-terminal#terminal')).not.toContainText('[ no recent activity ]');
+});
+
 test('live widgets show offline state when API is unreachable', async ({ page }) => {
   await page.route(`${API_BASE}/**`, async (route) => {
     await route.abort('failed');

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -237,6 +237,8 @@ test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
   assert.deepEqual(parseGithubEvents([sample]), [sample]);
   assert.deepEqual(parseGithubEvents({ events: 'invalid' }), []);
   assert.deepEqual(parseGithubEvents(null), []);
+  assert.deepEqual(parseGithubEvents({ events: [sample, sample, { type: 1 }] }), [sample]);
+  assert.deepEqual(parseGithubEvents([{ type: '', repo: 'x', message: 'm', timestamp: 't' }]), []);
 
   assert.equal(isGithubEventsPayload({ events: [] }), true);
   assert.equal(isGithubEventsPayload([sample]), true);
@@ -367,6 +369,52 @@ test('loadContentIndex rejects malformed topic entries', async () => {
 
   try {
     await assert.rejects(loadContentIndex(), /invalid content index payload/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchGithubEvents treats all-invalid items as offline and dedupes', async () => {
+  const { fetchGithubEvents, parseGithubEvents } = await loadTsModule('src/clanka-api.ts');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+
+  const sample = {
+    type: 'PushEvent',
+    repo: 'clankamode/site',
+    message: 'feat: test',
+    timestamp: '2026-03-03T03:40:00.000Z',
+  };
+
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return {
+        ok: true,
+        async json() {
+          return { events: [{ type: '', repo: 'x', message: 'm', timestamp: 't' }, { bad: true }] };
+        },
+      };
+    }
+    return {
+      ok: true,
+      async json() {
+        return { events: [sample, sample] };
+      },
+    };
+  };
+
+  try {
+    const offline = await fetchGithubEvents();
+    assert.deepEqual(offline, { ok: false, reason: 'offline' });
+
+    const recovered = await fetchGithubEvents();
+    assert.equal(recovered.ok, true);
+    if (recovered.ok) {
+      assert.deepEqual(recovered.events, [sample]);
+    }
+    assert.equal(attempts, 2);
+    assert.deepEqual(parseGithubEvents({ events: [sample, { ...sample }, sample] }), [sample]);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
#70 stopped caching `{ error: … }` as an empty events feed, but envelopes with only unusable items (blank repo/type, junk objects) still parsed to `[]` and rendered as “no recent activity”. Duplicate identical events also repeated in terminal/commit UI.

## Changes
- Require non-blank `type` / `repo` / `timestamp` for a valid event (empty `message` still allowed)
- If the envelope has entries but none parse → invalidate cache + `{ ok: false }` (unavailable), not empty success
- Dedupe identical `type+repo+message+timestamp` events

## Tests
- Unit: parse/dedupe + fetch recovery after all-invalid items
- Playwright: all-invalid event arrays show unavailable on commit feed + terminal

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

