### PR TITLE
fix(a11y): make skip-link main targets keyboard-focusable

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="home-page">
+<main id="main-content" class="home-page" tabindex="-1">
   <div class="home-composition">
   <div class="hero" aria-labelledby="hero-title">
     <pre class="ascii-ghost" aria-hidden="true">  ╔══════════╗

--- a/logs/index.html
+++ b/logs/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -421,7 +421,7 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -59,6 +59,11 @@ html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; text-size-adjust
   outline-offset: 2px;
 }
 
+/* Skip-link target: focusable for keyboard move, no full-page ring. */
+#main-content:focus {
+  outline: none;
+}
+
 body {
   font-family: var(--mono);
   background:

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -122,7 +122,8 @@ test('command palette restores skip-link tab order after close', async ({ page }
   await expect(page.locator('clanka-cmdk .palette')).toHaveCount(0);
 
   await expect(skip).not.toHaveAttribute('tabindex', '-1');
-  await expect(page.locator('#main-content')).not.toHaveAttribute('tabindex', '-1');
+  // Permanent skip-link target must be restored after cmdk clears inert chrome.
+  await expect(page.locator('#main-content')).toHaveAttribute('tabindex', '-1');
 });
 
 test('command palette Work nav from archive routes home', async ({ page }) => {

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -97,6 +97,16 @@ test.beforeEach(async ({ page }) => {
   await page.waitForSelector('#homepage-featured-log .featured-log');
 });
 
+test('skip link moves keyboard focus to main content', async ({ page }) => {
+  const skip = page.locator('.skip-link');
+  await expect(skip).toHaveAttribute('href', '#main-content');
+  await expect(page.locator('#main-content')).toHaveAttribute('tabindex', '-1');
+
+  await skip.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#main-content')).toBeFocused();
+});
+
 test('theme toggle persists after reload', async ({ page }) => {
   const toggle = page.locator('#theme-toggle');
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');

--- a/topics/agents/index.html
+++ b/topics/agents/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/identity/index.html
+++ b/topics/identity/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/memory/index.html
+++ b/topics/memory/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/operations/index.html
+++ b/topics/operations/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/philosophy/index.html
+++ b/topics/philosophy/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/systems/index.html
+++ b/topics/systems/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/teaching/index.html
+++ b/topics/teaching/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>

--- a/topics/tooling/index.html
+++ b/topics/tooling/index.html
@@ -41,7 +41,7 @@
 <div class="grain-overlay" aria-hidden="true"></div>
 <div class="scroll-progress" id="scrollProgress"></div>
 <clanka-cmdk></clanka-cmdk>
-<main id="main-content" class="content-page">
+<main id="main-content" class="content-page" tabindex="-1">
   <nav class="page-nav" aria-label="Breadcrumb">
     <a href="/">home</a>
     <span class="page-nav-sep">/</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `tabindex="-1"` to `#main-content` on the homepage and generated archive/topic shells so Skip to main content can move keyboard focus.
- Suppress the full-page focus ring on the skip target.
- Update cmdk restore expectations so permanent main `tabindex` survives palette open/close.

## Test plan
- [x] `npm run verify` (Node 24)
- [x] Playwright: skip link focuses `#main-content`; cmdk close restores `tabindex="-1"`
- [ ] Manual: Tab to skip link on `/` and `/logs/`, press Enter, confirm focus lands in main

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f544ca-5786-4bfc-b079-c132c6e24596?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f544ca-5786-4bfc-b079-c132c6e24596&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

