### PR TITLE
fix: normalize live task payloads and drop junk entries

### DIFF
--- a/src/clanka-tasks.ts
+++ b/src/clanka-tasks.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { getTaskDisplay, TASK_SKELETON_CARD_COUNT, type TaskItem } from './task-utils';
+import { getTaskDisplay, isTaskItem, TASK_SKELETON_CARD_COUNT, type TaskItem } from './task-utils';
 
 @customElement('clanka-tasks')
 export class ClankaTasks extends LitElement {
@@ -121,7 +121,7 @@ export class ClankaTasks extends LitElement {
   }
 
   private get safeTasks(): TaskItem[] {
-    return Array.isArray(this.tasks) ? this.tasks : [];
+    return Array.isArray(this.tasks) ? this.tasks.filter(isTaskItem) : [];
   }
 
   render() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import './clanka-tasks';
 import './clanka-cmdk';
 import { renderHomepageContent, renderHomepageStats } from './homepage-content';
 import { runWhenNearViewport } from './lazy-near-viewport';
+import { normalizeTasks } from './task-utils';
 
 type SyncPayload = {
   team?: Record<string, unknown>;
@@ -77,7 +78,7 @@ if (presence) {
       tasks.loading = false;
       tasks.error = '';
       if ('tasks' in data) {
-        tasks.tasks = Array.isArray(data.tasks) ? data.tasks : [];
+        tasks.tasks = normalizeTasks(data.tasks);
       }
     }
     if (agents) {

--- a/src/task-utils.ts
+++ b/src/task-utils.ts
@@ -16,20 +16,41 @@ export type TaskDisplay = {
 export const TASK_SKELETON_CARD_COUNT = 3;
 
 export function normalizeTaskStatus(value: unknown): TaskDisplay['statusClass'] {
-  switch (String(value ?? 'todo').trim().toLowerCase()) {
+  const raw = String(value ?? 'todo')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
+  switch (raw) {
     case 'doing':
+    case 'in_progress':
+    case 'wip':
+    case 'active':
+    case 'running':
       return 'doing';
     case 'done':
+    case 'complete':
+    case 'completed':
+    case 'finished':
       return 'done';
+    case 'todo':
+    case 'pending':
+    case 'backlog':
+    case '':
+      return 'todo';
     default:
       return 'todo';
   }
 }
 
-function stringifyTaskValue(value: string | number | undefined, fallback: string): string {
-  if (value === undefined || value === null) return fallback;
-  const s = String(value).trim();
-  return s.length > 0 ? s : fallback;
+function stringifyTaskValue(value: unknown, fallback: string): string {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value === 'string') {
+    const s = value.trim();
+    return s.length > 0 ? s : fallback;
+  }
+  // Objects/arrays/bools must not render as "[object Object]".
+  return fallback;
 }
 
 const FALLBACK_TASK_DISPLAY: TaskDisplay = {
@@ -40,8 +61,18 @@ const FALLBACK_TASK_DISPLAY: TaskDisplay = {
   priority: '?',
 };
 
+export function isTaskItem(value: unknown): value is TaskItem {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Keep only plain task objects from a /now tasks array. */
+export function normalizeTasks(value: unknown): TaskItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isTaskItem);
+}
+
 export function getTaskDisplay(task: TaskItem | null | undefined): TaskDisplay {
-  if (task == null) {
+  if (task == null || !isTaskItem(task)) {
     // Fresh object so callers cannot mutate a shared singleton.
     return { ...FALLBACK_TASK_DISPLAY };
   }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -156,6 +156,33 @@ test('task board shows empty state when API returns no tasks', async ({ page }) 
   await expect(tasks).toContainText('[ no tasks ]');
 });
 
+test('task board drops non-object items and maps in_progress status', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'triaging tasks',
+        status: 'active',
+        tasks: [
+          null,
+          'skip-me',
+          { title: 'Ship the board', status: 'in_progress', assignee: 'clanka', priority: 1 },
+          { title: { nested: true }, status: 'todo' },
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  const tasks = page.locator('clanka-tasks#tasks');
+  await expect(tasks).toContainText('Ship the board');
+  await expect(tasks.locator('.task-card')).toHaveCount(2);
+  await expect(tasks.locator('.status-doing')).toHaveCount(1);
+  await expect(tasks).not.toContainText('[object Object]');
+  await expect(tasks).toContainText('untitled');
+});
+
 test('fleet widget renders mocked repo cards', async ({ page }) => {
   const fleet = page.locator('clanka-fleet#fleet');
   await fleet.scrollIntoViewIfNeeded();

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -179,11 +179,19 @@ test('loadContentIndex retries after a rejected fetch', async () => {
 });
 
 test('task display helpers normalize status and preserve labels', async () => {
-  const { getTaskDisplay, normalizeTaskStatus, TASK_SKELETON_CARD_COUNT } = await loadTsModule('src/task-utils.ts');
+  const {
+    getTaskDisplay,
+    normalizeTaskStatus,
+    normalizeTasks,
+    TASK_SKELETON_CARD_COUNT,
+  } = await loadTsModule('src/task-utils.ts');
 
   assert.equal(TASK_SKELETON_CARD_COUNT, 3);
   assert.equal(normalizeTaskStatus(undefined), 'todo');
   assert.equal(normalizeTaskStatus(' Doing '), 'doing');
+  assert.equal(normalizeTaskStatus('in-progress'), 'doing');
+  assert.equal(normalizeTaskStatus('WIP'), 'doing');
+  assert.equal(normalizeTaskStatus('completed'), 'done');
   assert.equal(normalizeTaskStatus('blocked'), 'todo');
 
   assert.deepEqual(
@@ -215,6 +223,32 @@ test('task display helpers normalize status and preserve labels', async () => {
       assignee: 'unassigned',
       priority: '?',
     },
+  );
+
+  // Non-scalar fields must not stringify to "[object Object]".
+  assert.deepEqual(
+    getTaskDisplay({
+      title: { text: 'nope' },
+      assignee: ['a'],
+      priority: { level: 1 },
+    }),
+    {
+      statusClass: 'todo',
+      statusLabel: 'TODO',
+      title: 'untitled',
+      assignee: 'unassigned',
+      priority: '?',
+    },
+  );
+
+  assert.deepEqual(
+    normalizeTasks([
+      null,
+      'bad',
+      { title: 'Keep me', status: 'in_progress' },
+      [{ title: 'nested' }],
+    ]),
+    [{ title: 'Keep me', status: 'in_progress' }],
   );
 
   const a = getTaskDisplay(null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/now` task arrays could include `null`, strings, or nested junk. Those still rendered as untitled cards, and object field values became `[object Object]`. Common agent statuses like `in_progress` / `wip` also painted as TODO.

## Changes
- `normalizeTasks()` keeps only plain objects before wiring the board
- Status aliases: `in_progress` / `wip` / `active` / `running` → doing; `complete(d)` / `finished` → done
- `getTaskDisplay` only stringifies string/number fields (objects fall back)
- Widget `safeTasks` filters defensively as well

## Tests
- Unit: alias mapping, object-field fallbacks, `normalizeTasks`
- Playwright: mixed junk array keeps real cards, maps `in_progress`, no `[object Object]`

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

