### PR TITLE
fix: coalesce github events retries across live widgets

### DIFF
--- a/src/clanka-activity.ts
+++ b/src/clanka-activity.ts
@@ -1,7 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchEvents, relativeTime } from './time-utils';
-import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
 
@@ -85,7 +84,7 @@ export class ClankaActivity extends LitElement {
     this.loadInFlight = true;
 
     try {
-      const result = await withResultRetries(() => fetchEvents());
+      const result = await fetchEvents();
       if (!result.ok) {
         this.error = '[ activity unavailable ]';
         this.events = [];

--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -1,3 +1,5 @@
+import { withResultRetries } from './retry';
+
 const API_BASE = 'https://clanka-api.clankamode.workers.dev';
 const DEFAULT_TTL_MS = 15_000;
 const FETCH_TIMEOUT_MS = 5_000;
@@ -119,7 +121,9 @@ export type GithubEventsResult =
   | { ok: true; events: GithubEvent[] }
   | { ok: false; reason: 'offline' };
 
-export async function fetchGithubEvents(): Promise<GithubEventsResult> {
+let githubEventsLoad: Promise<GithubEventsResult> | null = null;
+
+async function loadGithubEventsOnce(): Promise<GithubEventsResult> {
   try {
     const data = await fetchJson('/github/events');
     if (!isGithubEventsPayload(data)) {
@@ -140,6 +144,19 @@ export async function fetchGithubEvents(): Promise<GithubEventsResult> {
   } catch {
     return { ok: false, reason: 'offline' };
   }
+}
+
+/**
+ * Shared events load with bounded retries. Concurrent callers (terminal,
+ * commit feed, activity) share one retry chain instead of stampeding.
+ */
+export function fetchGithubEvents(): Promise<GithubEventsResult> {
+  if (!githubEventsLoad) {
+    githubEventsLoad = withResultRetries(() => loadGithubEventsOnce()).finally(() => {
+      githubEventsLoad = null;
+    });
+  }
+  return githubEventsLoad;
 }
 
 export type NowPayload = {

--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -1,5 +1,3 @@
-import { withResultRetries } from './retry';
-
 const API_BASE = 'https://clanka-api.clankamode.workers.dev';
 const DEFAULT_TTL_MS = 15_000;
 const FETCH_TIMEOUT_MS = 5_000;
@@ -123,6 +121,12 @@ export type GithubEventsResult =
 
 let githubEventsLoad: Promise<GithubEventsResult> | null = null;
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 async function loadGithubEventsOnce(): Promise<GithubEventsResult> {
   try {
     const data = await fetchJson('/github/events');
@@ -146,13 +150,29 @@ async function loadGithubEventsOnce(): Promise<GithubEventsResult> {
   }
 }
 
+/** Local retry helper — keep clanka-api import-free for the content-test loader. */
+async function loadGithubEventsWithRetries(
+  attempts = 3,
+  baseDelayMs = 200,
+): Promise<GithubEventsResult> {
+  let last: GithubEventsResult | undefined;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await loadGithubEventsOnce();
+    if (last.ok) return last;
+    if (attempt < attempts - 1) {
+      await delay(baseDelayMs * (attempt + 1));
+    }
+  }
+  return last ?? { ok: false, reason: 'offline' };
+}
+
 /**
  * Shared events load with bounded retries. Concurrent callers (terminal,
  * commit feed, activity) share one retry chain instead of stampeding.
  */
 export function fetchGithubEvents(): Promise<GithubEventsResult> {
   if (!githubEventsLoad) {
-    githubEventsLoad = withResultRetries(() => loadGithubEventsOnce()).finally(() => {
+    githubEventsLoad = loadGithubEventsWithRetries().finally(() => {
       githubEventsLoad = null;
     });
   }

--- a/src/clanka-commits.ts
+++ b/src/clanka-commits.ts
@@ -1,5 +1,4 @@
 import { fetchGithubEvents, type GithubEvent } from './clanka-api';
-import { withResultRetries } from './retry';
 
 const COMMIT_TYPES = ['feat', 'fix', 'chore', 'docs', 'test', 'refactor', 'ci', 'build', 'style'] as const;
 
@@ -64,7 +63,7 @@ export async function loadCommitFeed(): Promise<void> {
   commitFeedLoadInFlight = true;
 
   try {
-    const result = await withResultRetries(() => fetchGithubEvents());
+    const result = await fetchGithubEvents();
 
     if (!result.ok) {
       setFeedText('// activity unavailable');

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -1,7 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { fetchEvents, relativeTime } from './time-utils';
-import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
 
@@ -100,7 +99,7 @@ export class ClankaTerminal extends LitElement {
     this.loadInFlight = true;
 
     try {
-      const result = await withResultRetries(() => fetchEvents());
+      const result = await fetchEvents();
       if (!result.ok) {
         this.error = '[ offline — activity unavailable ]';
         this.events = [];

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -280,6 +280,26 @@ test('live widgets show offline state when API is unreachable', async ({ page })
   await expect(page.locator('#commit-feed')).toContainText('// activity unavailable');
 });
 
+test('github events offline path coalesces retries across terminal and commit feed', async ({ page }) => {
+  let eventsHits = 0;
+  await page.route(`${API_BASE}/github/events`, async (route) => {
+    eventsHits += 1;
+    await route.abort('failed');
+  });
+
+  await page.reload();
+  await page.locator('#commit-feed').scrollIntoViewIfNeeded();
+  await page.locator('clanka-terminal#terminal').scrollIntoViewIfNeeded();
+  await expect(page.locator('#commit-feed')).toContainText('// activity unavailable');
+  await expect(page.locator('clanka-terminal#terminal')).toContainText(
+    '[ offline — activity unavailable ]',
+  );
+
+  // One shared retry chain (≤3), not 3 attempts × each widget.
+  expect(eventsHits).toBeGreaterThan(0);
+  expect(eventsHits).toBeLessThanOrEqual(3);
+});
+
 test('partial /now payloads do not wipe tasks or agents', async ({ page }) => {
   await page.route(`${API_BASE}/now`, async (route) => {
     await route.fulfill({

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -478,7 +478,8 @@ test('fetchGithubEvents treats all-invalid items as offline and dedupes', async 
 
   globalThis.fetch = async () => {
     attempts += 1;
-    if (attempts === 1) {
+    // Exhaust the shared retry budget (3) on unusable items, then recover.
+    if (attempts <= 3) {
       return {
         ok: true,
         async json() {
@@ -503,8 +504,40 @@ test('fetchGithubEvents treats all-invalid items as offline and dedupes', async 
     if (recovered.ok) {
       assert.deepEqual(recovered.events, [sample]);
     }
-    assert.equal(attempts, 2);
+    assert.equal(attempts, 4);
     assert.deepEqual(parseGithubEvents({ events: [sample, { ...sample }, sample] }), [sample]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchGithubEvents coalesces concurrent callers through one retry chain', async () => {
+  const { fetchGithubEvents } = await loadTsModule('src/clanka-api.ts');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+
+  globalThis.fetch = async () => {
+    attempts += 1;
+    return {
+      ok: false,
+      status: 503,
+      async json() {
+        return { error: 'unavailable' };
+      },
+    };
+  };
+
+  try {
+    const first = fetchGithubEvents();
+    const second = fetchGithubEvents();
+    const third = fetchGithubEvents();
+    const results = await Promise.all([first, second, third]);
+
+    for (const result of results) {
+      assert.deepEqual(result, { ok: false, reason: 'offline' });
+    }
+    // Default withResultRetries budget is 3 — shared, not 3× callers.
+    assert.equal(attempts, 3);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Terminal, activity, and the commit feed each wrapped `fetchGithubEvents()` in `withResultRetries`. On offline/malformed responses that return `{ ok: false }` (not throw), staggered widget retries could multiply `/github/events` traffic.

Rebased onto latest `main` after #84 (invalid event items).

## Changes
- Bounded retries live inside `fetchGithubEvents()` (import-free helper for the content-test loader)
- Concurrent callers share one in-flight retry chain
- Terminal / activity / commit feed call the shared loader once

## Tests
- Unit: three concurrent callers → exactly 3 HTTP attempts; all-invalid still recovers after retry budget
- Playwright: offline events path across commit feed + terminal stays ≤3 hits

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

