### PR TITLE
fix(content): improve archive and topic empty states offline

### DIFF
--- a/src/logs-page.ts
+++ b/src/logs-page.ts
@@ -29,8 +29,18 @@ async function renderArchivePage(): Promise<void> {
     populateSelect(topicSelect, [{ value: 'all', label: 'all topics' }]);
     populateSelect(yearSelect, [{ value: 'all', label: 'all years' }]);
     resultsCount.textContent = 'archive unavailable';
-    resultsHost.textContent = '';
-    resultsHost.textContent = 'archive unavailable';
+    resultsHost.replaceChildren();
+    const unavailable = document.createElement('p');
+    unavailable.className = 'archive-empty';
+    unavailable.setAttribute('role', 'status');
+    unavailable.textContent = 'archive unavailable';
+    resultsHost.append(unavailable);
+    formatButtons.forEach((button) => {
+      button.disabled = true;
+    });
+    searchInput.disabled = true;
+    topicSelect.disabled = true;
+    yearSelect.disabled = true;
     return;
   }
 
@@ -62,9 +72,11 @@ async function renderArchivePage(): Promise<void> {
       return haystack.includes(query);
     });
 
-    resultsHost.textContent = '';
+    resultsHost.replaceChildren();
     if (filtered.length === 0) {
       const empty = document.createElement('p');
+      empty.className = 'archive-empty';
+      empty.setAttribute('role', 'status');
       empty.textContent = 'no dispatches match these filters';
       resultsHost.append(empty);
     } else {

--- a/src/styles.css
+++ b/src/styles.css
@@ -696,6 +696,13 @@ section {
   gap: 12px;
 }
 
+.archive-empty {
+  margin: 0;
+  color: var(--dim);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+}
+
 .archive-preview-row {
   grid-template-columns: minmax(0, 1fr) auto;
   padding: 14px 0;

--- a/src/topic-page.ts
+++ b/src/topic-page.ts
@@ -16,23 +16,32 @@ async function renderTopicPage(): Promise<void> {
     return;
   }
 
+  const renderPostsMessage = (message: string): void => {
+    postsHost.replaceChildren();
+    const empty = document.createElement('p');
+    empty.className = 'archive-empty';
+    empty.setAttribute('role', 'status');
+    empty.textContent = message;
+    postsHost.append(empty);
+  };
+
   let contentIndex;
   try {
     contentIndex = await loadContentIndex();
   } catch {
     description.textContent = 'archive unavailable';
-    count.textContent = '';
+    count.textContent = 'archive unavailable';
     latest.textContent = '';
-    postsHost.textContent = '';
+    renderPostsMessage('archive unavailable');
     return;
   }
 
   const topic = contentIndex.topics.find((entry) => entry.slug === slug);
   if (!topic) {
     description.textContent = 'unknown topic';
-    count.textContent = '';
+    count.textContent = 'unknown topic';
     latest.textContent = '';
-    postsHost.textContent = '';
+    renderPostsMessage('no dispatches for this topic');
     return;
   }
 
@@ -40,7 +49,12 @@ async function renderTopicPage(): Promise<void> {
   count.textContent = formatCount(topic.count, 'dispatch');
   latest.textContent = topic.latestDate ? `last dispatch · ${topic.latestDate}` : 'last dispatch · n/a';
 
-  postsHost.textContent = '';
+  postsHost.replaceChildren();
+  if (topic.posts.length === 0) {
+    renderPostsMessage('no dispatches for this topic');
+    return;
+  }
+
   topic.posts.forEach((post, index) => {
     const detailed = contentIndex.posts.find((entry) => entry.slug === post.slug) ?? post;
     const card = createArchiveCard(detailed as ContentPost);

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -89,8 +89,26 @@ test('archive search with no matches shows an empty state message', async ({ pag
 
   await page.locator('#archive-search-input').fill('zzznomatchzzz');
   await expect(page.locator('#archive-results-count')).toHaveText('0 dispatches shown');
-  await expect(page.locator('#archive-results')).toHaveText('no dispatches match these filters');
+  await expect(page.locator('#archive-results .archive-empty')).toHaveAttribute('role', 'status');
+  await expect(page.locator('#archive-results .archive-empty')).toHaveText('no dispatches match these filters');
   await expect(page.locator('#archive-results .archive-card')).toHaveCount(0);
+});
+
+test('archive shows unavailable empty state when content-index fails', async ({ page }) => {
+  await page.route('**/content-index.json', async (route) => {
+    await route.abort('failed');
+  });
+
+  await page.goto('/logs/');
+  await page.waitForSelector('#archive-results .archive-empty');
+
+  await expect(page.locator('#archive-results-count')).toHaveText('archive unavailable');
+  await expect(page.locator('#archive-results .archive-empty')).toHaveAttribute('role', 'status');
+  await expect(page.locator('#archive-results .archive-empty')).toHaveText('archive unavailable');
+  await expect(page.locator('#archive-search-input')).toBeDisabled();
+  await expect(page.locator('#archive-topic-select')).toBeDisabled();
+  await expect(page.locator('#archive-year-select')).toBeDisabled();
+  await expect(page.locator('.archive-format-buttons .filter-chip').first()).toBeDisabled();
 });
 
 test('topic pages show derived counts and matching posts', async ({ page }) => {
@@ -111,6 +129,21 @@ test('topic pages show derived counts and matching posts', async ({ page }) => {
   await expect(page.locator('#topic-posts .archive-card').first().locator('.archive-card-title')).toContainText(
     requireValue(topic.posts[0], 'expected at least one post for the agents topic').title,
   );
+});
+
+test('topic page shows unavailable empty state when content-index fails', async ({ page }) => {
+  await page.route('**/content-index.json', async (route) => {
+    await route.abort('failed');
+  });
+
+  await page.goto('/topics/agents/');
+  await page.waitForSelector('#topic-posts .archive-empty');
+
+  await expect(page.locator('#topic-description')).toHaveText('archive unavailable');
+  await expect(page.locator('#topic-count')).toHaveText('archive unavailable');
+  await expect(page.locator('#topic-posts .archive-empty')).toHaveAttribute('role', 'status');
+  await expect(page.locator('#topic-posts .archive-empty')).toHaveText('archive unavailable');
+  await expect(page.locator('#topic-posts .archive-card')).toHaveCount(0);
 });
 
 test('post pages render topic chips, related posts, and generated navigation', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When `content-index.json` failed to load, the archive page left filters interactive while showing a bare text node, and topic pages cleared `#topic-posts` with no message — a blank dispatches section.

## Change

- Archive unavailable/empty results use `role="status"` `.archive-empty` copy; filters disable when the index is offline
- Topic pages render the same status empty state for unavailable/unknown/zero-post cases
- Playwright coverage for both offline paths

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/archive.spec.ts -g 'empty state|unavailable'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

