### PR TITLE
fix(audio): keep j/k from navigating away during listen mode

### DIFF
--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -133,8 +133,22 @@
     if (which === 'prev') return links[0]?.getAttribute('href') || null;
     return links.length > 1 ? links[1].getAttribute('href') : null;
   };
+  const shouldIgnorePostShortcut = (e) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return true;
+    const target = e.target;
+    if (!(target instanceof Element)) return false;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+      return true;
+    }
+    if (target.isContentEditable || target.closest('[contenteditable="true"]')) return true;
+    // Never eject listeners mid-playback / while focusing the player chrome.
+    if (document.body.classList.contains('listen-mode')) return true;
+    if (target.closest('.audio-player')) return true;
+    return false;
+  };
+
   document.addEventListener('keydown', (e) => {
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (shouldIgnorePostShortcut(e)) return;
     if (e.key === 'j') {
       const next = resolveNavHref('next');
       if (next) window.location.href = next;
@@ -147,7 +161,7 @@
 
   // 4. Back to top on 't'
   document.addEventListener('keydown', (e) => {
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (shouldIgnorePostShortcut(e)) return;
     if (e.key === 't') {
       const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
         ? 'auto'

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import path from 'path';
 
 type ContentIndex = {
   posts: Array<{
@@ -158,6 +159,22 @@ test('post j/k keyboard navigation follows enhanced prev/next links', async ({ p
 
   await page.keyboard.press('k');
   await expect(page).toHaveURL(prevHref!);
+});
+
+test('post j/k shortcuts stay put during listen mode', async ({ page }) => {
+  await page.addInitScript({ path: path.resolve(__dirname, 'audio-mock.js') });
+  await page.goto('/posts/2026-02-21-deploy-fix.html');
+  await page.waitForSelector('.ap-play');
+  await page.waitForSelector('.post-nav-enhanced a[data-nav]');
+
+  const urlBefore = page.url();
+  await page.click('.ap-play');
+  await expect(page.locator('body')).toHaveClass(/listen-mode/);
+
+  await page.keyboard.press('j');
+  await page.keyboard.press('k');
+  await expect(page).toHaveURL(urlBefore);
+  await expect(page.locator('body')).toHaveClass(/listen-mode/);
 });
 
 test('now page exposes skip link and heading outline', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On dispatch pages, `j` / `k` jump to next/prev posts whenever focus is not in an input. During listen mode that ejects the listener mid-playback and kills audio.

## Change

- Ignore post keyboard shortcuts while `body.listen-mode` is active or focus is inside `.audio-player`
- Also ignore for contenteditable targets and when meta/ctrl/alt are held
- Playwright coverage: shortcuts still navigate normally, but stay put during listen mode

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/archive.spec.ts -g 'j/k'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

