### PR TITLE
fix(audio): let Space pause and resume listen mode

### DIFF
--- a/posts/audio-player.js
+++ b/posts/audio-player.js
@@ -13,6 +13,7 @@
   let speed = 1;
   let audioCtx, analyser, dataArray, sourceNode;
   let listenMode = false;
+  let playbackSession = false;
   let animFrame;
 
   // Cache the accent color so the animation loop never has to call
@@ -115,6 +116,7 @@
   function enterListenMode() {
     if (listenMode) return;
     listenMode = true;
+    playbackSession = true;
     accentColor = readAccentColor();
     themeObserver = new MutationObserver(() => { accentColor = readAccentColor(); });
     themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
@@ -237,7 +239,8 @@
     btn.setAttribute('aria-label', playing ? 'Pause audio narration' : 'Play audio narration');
   }
 
-  btn.addEventListener('click', () => {
+  function togglePlayback() {
+    if (container.getAttribute('data-audio-error') === '1' || btn.disabled) return;
     initAudio();
     if (audio.paused) {
       if (audioCtx && audioCtx.state === 'suspended') audioCtx.resume();
@@ -259,6 +262,36 @@
       setPlayState(false);
       exitListenMode();
     }
+  }
+
+  btn.addEventListener('click', () => {
+    togglePlayback();
+  });
+
+  // Space / media keys pause-resume during listen mode (or while focused in the player)
+  // so the page does not scroll away from the active paragraph.
+  document.addEventListener('keydown', (e) => {
+    const isSpace = e.code === 'Space' || e.key === ' ';
+    const isMediaToggle = e.key === 'MediaPlayPause';
+    if (!isSpace && !isMediaToggle) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    const target = e.target;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+      return;
+    }
+    if (target instanceof HTMLElement && (target.isContentEditable || target.closest('[contenteditable="true"]'))) {
+      return;
+    }
+
+    const inPlayer = target instanceof Element && Boolean(target.closest('.audio-player'));
+    // Keep Space bound after pause so resume does not require re-focusing the player.
+    if (!playbackSession && !listenMode && !inPlayer) return;
+    // Focused player buttons already activate via native Space — avoid double-toggle.
+    if (isSpace && target instanceof HTMLButtonElement) return;
+
+    e.preventDefault();
+    togglePlayback();
   });
 
   skips.forEach(s => s.addEventListener('click', () => {

--- a/tests/audio-player.spec.ts
+++ b/tests/audio-player.spec.ts
@@ -62,6 +62,24 @@ test('pause exits listen-mode class on body', async ({ page }) => {
   await expect(page.locator('body')).not.toHaveClass(/listen-mode/);
 });
 
+test('Space toggles play/pause during listen mode without leaving the page', async ({ page }) => {
+  const urlBefore = page.url();
+  await page.click('.ap-play');
+  await expect(page.locator('body')).toHaveClass(/listen-mode/);
+  await expect(page.locator('.ap-play')).toHaveAttribute('aria-label', 'Pause audio narration');
+
+  // Blur the play button so Space is handled by the document listen-mode shortcut.
+  await page.locator('body').click({ position: { x: 8, y: 8 } });
+  await page.keyboard.press('Space');
+  await expect(page.locator('body')).not.toHaveClass(/listen-mode/);
+  await expect(page.locator('.ap-play')).toHaveAttribute('aria-label', 'Play audio narration');
+  await expect(page).toHaveURL(urlBefore);
+
+  await page.keyboard.press('Space');
+  await expect(page.locator('body')).toHaveClass(/listen-mode/);
+  await expect(page.locator('.ap-play')).toHaveAttribute('aria-label', 'Pause audio narration');
+});
+
 // ── 4. Paragraph sync ─────────────────────────────────────────────────────────
 
 test('paragraph sync — correct element gets lm-active', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

While a dispatch is narrating, pressing Space scrolls the page instead of pausing. Easy to lose place mid-listen.

## Change

- Extract a shared `togglePlayback()` used by the play button
- Bind Space / `MediaPlayPause` once a listen session has started (or while focus is inside `.audio-player`)
- `preventDefault` so the page does not scroll; skip focused buttons to avoid double-toggle
- Playwright coverage for pause + resume via Space

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/audio-player.spec.ts -g 'Space|listen-mode'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

