### PR TITLE
fix: treat unusable fleet repo lists as unavailable

### DIFF
--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -272,6 +272,33 @@ export function isFleetSummaryPayload(payload: unknown): boolean {
   return false;
 }
 
+const FLEET_TIERS = new Set(['ops', 'infra', 'core', 'quality', 'policy', 'template']);
+
+function fleetRepoCandidates(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (!isPlainObject(payload)) return [];
+
+  if (Array.isArray(payload.repos)) return payload.repos;
+  if (Array.isArray(payload.fleet)) return payload.fleet;
+
+  if (isPlainObject(payload.summary)) {
+    const summary = payload.summary;
+    if (Array.isArray(summary.repos)) return summary.repos;
+    if (Array.isArray(summary.fleet)) return summary.fleet;
+  }
+
+  return [];
+}
+
+/** True when a candidate can become a fleet card (named repo + known tier). */
+export function isUsableFleetRepo(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const repo = String(value.repo ?? value.name ?? value.full_name ?? '').trim();
+  if (!repo) return false;
+  const tier = String(value.tier ?? '').trim().toLowerCase();
+  return FLEET_TIERS.has(tier);
+}
+
 export async function fetchFleetSummary(): Promise<unknown> {
   const data = await fetchJson('/fleet/summary');
   if (!isFleetSummaryPayload(data)) {
@@ -279,5 +306,13 @@ export async function fetchFleetSummary(): Promise<unknown> {
     invalidateEndpoint('/fleet/summary');
     throw new Error('Invalid /fleet/summary payload');
   }
+
+  const candidates = fleetRepoCandidates(data);
+  // Entries present but none usable → unavailable, not an honest empty registry.
+  if (candidates.length > 0 && !candidates.some(isUsableFleetRepo)) {
+    invalidateEndpoint('/fleet/summary');
+    throw new Error('Invalid /fleet/summary repos');
+  }
+
   return data;
 }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -192,6 +192,28 @@ test('fleet widget renders mocked repo cards', async ({ page }) => {
   await expect(fleet.locator('.status-pill.online')).toHaveCount(2);
 });
 
+test('all-unusable fleet repos show offline instead of empty registry', async ({ page }) => {
+  await page.route(`${API_BASE}/fleet/summary`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        repos: [
+          { repo: 'clankamode/ghost' },
+          { name: 'clankamode/other', tier: 'mystery' },
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  const fleet = page.locator('clanka-fleet#fleet');
+  await fleet.scrollIntoViewIfNeeded();
+  await expect(fleet).toContainText('[ api unreachable ]');
+  await expect(fleet).not.toContainText('[ fleet registry empty ]');
+  await expect(fleet.locator('.sync')).toHaveText('OFFLINE');
+});
+
 test('fleet hides status pill when API omits online state', async ({ page }) => {
   await page.route(`${API_BASE}/fleet/summary`, async (route) => {
     await route.fulfill({

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -262,6 +262,7 @@ test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
     isGithubEventsPayload,
     isFleetSummaryPayload,
     isGithubStatsPayload,
+    isUsableFleetRepo,
   } = await loadTsModule('src/clanka-api.ts');
   const sample = {
     type: 'PushEvent',
@@ -288,6 +289,12 @@ test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
   assert.equal(isFleetSummaryPayload({ summary: { repos: [] } }), true);
   assert.equal(isFleetSummaryPayload({ message: 'no registry' }), false);
   assert.equal(isFleetSummaryPayload(null), false);
+
+  assert.equal(isUsableFleetRepo({ repo: 'clankamode/api', tier: 'core' }), true);
+  assert.equal(isUsableFleetRepo({ name: 'clankamode/api', tier: 'ops' }), true);
+  assert.equal(isUsableFleetRepo({ repo: 'clankamode/api' }), false);
+  assert.equal(isUsableFleetRepo({ repo: '', tier: 'core' }), false);
+  assert.equal(isUsableFleetRepo({ bad: true }), false);
 
   assert.equal(isGithubStatsPayload({ repoCount: 0, totalStars: 0 }), true);
   assert.equal(isGithubStatsPayload({ lastPushedAt: '2026-08-02T02:03:12Z', lastPushedRepo: 'site' }), true);
@@ -538,6 +545,49 @@ test('fetchNow invalidates cache after rejecting a malformed payload', async () 
     const recovered = await fetchNow();
     assert.deepEqual(recovered, { current: 'recovered', status: 'active' });
     assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchFleetSummary rejects all-unusable repo entries and invalidates cache', async () => {
+  const { fetchFleetSummary } = await loadTsModule('src/clanka-api.ts');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return {
+        ok: true,
+        async json() {
+          return {
+            repos: [
+              { repo: 'clankamode/x' },
+              { name: 'clankamode/y', tier: 'unknown' },
+              { bad: true },
+            ],
+          };
+        },
+      };
+    }
+    return {
+      ok: true,
+      async json() {
+        return {
+          totalRepos: 1,
+          repos: [{ repo: 'clankamode/clanka-api', tier: 'core', criticality: 'high' }],
+        };
+      },
+    };
+  };
+
+  try {
+    await assert.rejects(fetchFleetSummary(), /Invalid \/fleet\/summary repos/);
+    const recovered = await fetchFleetSummary();
+    assert.equal(attempts, 2);
+    assert.equal(Array.isArray(recovered.repos), true);
+    assert.equal(recovered.repos[0].repo, 'clankamode/clanka-api');
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/fleet/summary` envelopes with junk repo entries (missing name/tier) still counted as a successful empty registry → `SYNCED` + `[ fleet registry empty ]`, and the bad payload stayed TTL-cached.

## Changes
- Require at least one usable repo (named + known tier) when candidates are present
- Otherwise invalidate cache and throw (widget shows offline/unreachable)
- True empty `repos: []` remains a valid empty registry

## Tests
- Unit: `isUsableFleetRepo` + cache invalidation recovery
- Playwright: all-unusable fleet payload → OFFLINE, not empty registry

```bash
npm run verify
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

