### PR TITLE
fix(fleet): treat unusable repo arrays as unavailable

### DIFF
--- a/src/clanka-fleet.ts
+++ b/src/clanka-fleet.ts
@@ -262,11 +262,18 @@ export class ClankaFleet extends LitElement {
 
     try {
       const data = await withRetries(() => fetchFleetSummary());
-      const repos = this.extractRepos(data);
-      this.repos = repos;
-      // Valid empty registry is still a successful sync — not offline.
-      this.live = true;
-      this.error = repos.length ? '' : '[ fleet registry empty ]';
+      const { repos, sourceCount } = this.extractRepos(data);
+      // Envelope with entries that all fail normalization is unavailable — not an empty sync.
+      if (sourceCount > 0 && repos.length === 0) {
+        this.repos = [];
+        this.live = false;
+        this.error = '[ fleet unavailable ]';
+      } else {
+        this.repos = repos;
+        // Valid empty registry is still a successful sync — not offline.
+        this.live = true;
+        this.error = repos.length ? '' : '[ fleet registry empty ]';
+      }
     } catch {
       this.repos = [];
       this.live = false;
@@ -289,17 +296,19 @@ export class ClankaFleet extends LitElement {
     return this.repos.some((repo) => repo.online !== null) ? 'live' : 'synced';
   }
 
-  private extractRepos(data: unknown): FleetRepo[] {
+  private extractRepos(data: unknown): { repos: FleetRepo[]; sourceCount: number } {
     const source = this.pickRepoArray(data);
-    if (!source.length) return [];
+    if (!source.length) return { repos: [], sourceCount: 0 };
 
-    return source
+    const repos = source
       .map((item) => this.normalizeRepo(item))
       .filter((item): item is FleetRepo => item !== null)
       .sort((a, b) => {
         const tierOrder = TIERS.indexOf(a.tier) - TIERS.indexOf(b.tier);
         return tierOrder !== 0 ? tierOrder : a.repo.localeCompare(b.repo);
       });
+
+    return { repos, sourceCount: source.length };
   }
 
   private pickRepoArray(data: unknown): unknown[] {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -192,6 +192,30 @@ test('fleet widget renders mocked repo cards', async ({ page }) => {
   await expect(fleet.locator('.status-pill.online')).toHaveCount(2);
 });
 
+test('fleet treats all-invalid repo entries as unavailable not empty', async ({ page }) => {
+  await page.route(`${API_BASE}/fleet/summary`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        repos: [
+          { repo: 'clankamode/broken', tier: 'not-a-tier', criticality: 'critical' },
+          { name: '', tier: 'ops', criticality: 'high' },
+          null,
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  const fleet = page.locator('clanka-fleet#fleet');
+  await fleet.scrollIntoViewIfNeeded();
+  await expect(fleet.locator('.fallback')).toHaveText('[ fleet unavailable ]');
+  await expect(fleet.locator('.sync')).toHaveText('OFFLINE');
+  await expect(fleet.locator('.repo')).toHaveCount(0);
+  await expect(fleet).not.toContainText('[ fleet registry empty ]');
+});
+
 test('fleet hides status pill when API omits online state', async ({ page }) => {
   await page.route(`${API_BASE}/fleet/summary`, async (route) => {
     await route.fulfill({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`/fleet/summary` envelopes with a non-empty `repos` array still counted as a successful sync after every entry failed normalization (bad tier, blank name, etc.). The widget painted `SYNCED` + `[ fleet registry empty ]` — API junk looking like a healthy empty registry.

## Change

- Track source array length vs normalized repo count
- If the API sent entries but none parse → `OFFLINE` / `[ fleet unavailable ]`
- Truly empty `repos: []` still means a successful empty registry
- Playwright coverage for the all-invalid path

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/cmdk-offline.spec.ts -g 'fleet'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

