### PR TITLE
fix(content): stop stacking read/listen meta on audio posts

### DIFF
--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -115,7 +115,12 @@
     const words = (clone.textContent || '').trim().split(/\s+/).filter(Boolean).length;
     const mins = Math.max(1, Math.ceil(words / 220));
     const meta = document.querySelector('.meta');
-    if (meta && !/\bmin read\b/i.test(meta.textContent || '')) {
+    // Listen posts already advertise duration ("N min listen"); don't stack a conflicting read estimate.
+    if (
+      meta
+      && !/\bmin read\b/i.test(meta.textContent || '')
+      && !/\bmin listen\b/i.test(meta.textContent || '')
+    ) {
       meta.innerHTML += ` &nbsp;·&nbsp; ${mins} min read`;
     }
   }
@@ -181,7 +186,15 @@
       if (!currentPost) return;
 
       const meta = document.querySelector('.meta');
-      if (meta && currentPost.audio && !/listen available/i.test(meta.textContent || '')) {
+      // Skip the redundant badge when the player is already above the fold (or meta already says listen).
+      const hasVisiblePlayer = Boolean(document.querySelector('.audio-player[data-src]'));
+      if (
+        meta
+        && currentPost.audio
+        && !hasVisiblePlayer
+        && !/listen available/i.test(meta.textContent || '')
+        && !/\bmin listen\b/i.test(meta.textContent || '')
+      ) {
         meta.innerHTML += ' &nbsp;·&nbsp; listen available';
       }
 

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -126,6 +126,17 @@ test('post pages render topic chips, related posts, and generated navigation', a
   expect(count).toBeLessThanOrEqual(2);
 });
 
+test('listen posts do not stack min read or listen available over listen meta', async ({ page }) => {
+  await page.goto('/posts/2026-02-21-deploy-fix.html');
+  await page.waitForSelector('.post-topic-chips');
+  await expect(page.locator('.audio-player[data-src]')).toHaveCount(1);
+
+  const meta = page.locator('.meta');
+  await expect(meta).toContainText(/min listen/i);
+  await expect(meta).not.toContainText(/min read/i);
+  await expect(meta).not.toContainText(/listen available/i);
+});
+
 test('posts keep chronological prev/next nav when content-index is offline', async ({ page }) => {
   await page.route('**/content-index.json', async (route) => {
     await route.abort('failed');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Listen dispatches already ship `N min listen` in `.meta` and an above-the-fold audio player. `post-enhance.js` still appended `min read` and `listen available`, producing conflicting duration signals and a redundant listen cue.

## Change

- Skip estimated read-time injection when meta already contains `min listen`
- Skip `listen available` when a `.audio-player[data-src]` is present or meta already says listen
- Playwright coverage on a listen dispatch

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/archive.spec.ts -g 'listen posts'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

