### PR TITLE
fix(content): label listen posts with min listen in archive

### DIFF
--- a/src/content-browser.ts
+++ b/src/content-browser.ts
@@ -21,11 +21,11 @@ function formatDispatchNumber(number: unknown): string {
   return '—';
 }
 
-function formatReadMinutes(minutes: unknown): string {
+function formatDurationMinutes(minutes: unknown, audio = false): string {
   if (typeof minutes === 'number' && Number.isFinite(minutes) && minutes > 0) {
-    return `${Math.ceil(minutes)} min read`;
+    return `${Math.ceil(minutes)} min ${audio ? 'listen' : 'read'}`;
   }
-  return 'quick read';
+  return audio ? 'quick listen' : 'quick read';
 }
 
 function createMetaBadge(label: string): HTMLSpanElement {
@@ -75,7 +75,7 @@ export function createArchiveCard(post: ContentPost): HTMLElement {
   const meta = document.createElement('div');
   meta.className = 'archive-card-meta';
   meta.append(
-    createMetaBadge(formatReadMinutes(post.estimatedReadMinutes)),
+    createMetaBadge(formatDurationMinutes(post.estimatedReadMinutes, Boolean(post.audio))),
     createMetaBadge(post.audio ? 'listen available' : 'read only'),
   );
 

--- a/src/homepage-content.ts
+++ b/src/homepage-content.ts
@@ -101,8 +101,11 @@ export async function renderHomepageContent(): Promise<void> {
 
         const meta = document.createElement('div');
         meta.className = 'featured-meta';
+        const durationLabel = readMinutes !== null
+          ? `${readMinutes} min ${featured.audio ? 'listen' : 'read'}`
+          : (featured.audio ? 'listen time unknown' : 'read time unknown');
         meta.append(
-          createFeaturedMeta(readMinutes !== null ? `${readMinutes} min read` : 'read time unknown'),
+          createFeaturedMeta(durationLabel),
           createFeaturedMeta(featured.audio ? 'audio available' : 'text only'),
           createFeaturedMeta(`${featuredTopics.length} topic lanes`),
         );

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -64,8 +64,10 @@ test('archive supports text and format filtering', async ({ page }) => {
   await page.getByRole('button', { name: 'listen' }).click();
   await expect(page.locator('#archive-results-count')).toHaveText(`${formatDispatchCount(listenPosts.length)} shown`);
   await expect(results).toHaveCount(listenPosts.length);
+  await expect(results.first().locator('.archive-meta-badge').nth(0)).toContainText(/min listen/);
   await expect(results.first().locator('.archive-meta-badge').nth(1)).toContainText('listen available');
   await expect(page.locator('#archive-results')).not.toContainText(firstReadOnlyPost.title);
+  await expect(results.first()).not.toContainText(/min read/);
 });
 
 test('archive topic filter narrows results to matching dispatches', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Archive cards (and the homepage featured card) labeled audio dispatches as `N min read`, even though the post page itself advertises `N min listen`. That misleads browsers choosing listen vs read.

## Change

- Archive duration badge uses `min listen` when `audio` is true
- Homepage featured duration badge matches the same rule
- Keep the existing `listen available` / `audio available` format badges
- Playwright: listen filter cards show `min listen`, not `min read`

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/archive.spec.ts -g 'listen'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7dcd24-482c-422e-bd9a-e2f4c0a42790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

