### PR TITLE
fix terminal/activity event type and blank message display

### DIFF
--- a/src/clanka-activity.ts
+++ b/src/clanka-activity.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { fetchEvents, relativeTime } from './time-utils';
+import { displayEventMessage, fetchEvents, normalizeEventType, relativeTime } from './time-utils';
 import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
@@ -106,18 +106,22 @@ export class ClankaActivity extends LitElement {
         <div class="sec-line"></div>
       </div>
       ${this.loading
-        ? html`<div class="status-fallback"><span class="loading-text">[ loading... ]</span></div>`
+        ? html`<div class="status-fallback" aria-busy="true"><span class="loading-text">[ loading... ]</span></div>`
         : this.error
-          ? html`<div class="status-fallback">${this.error}</div>`
+          ? html`<div class="status-fallback" role="status" aria-live="polite">${this.error}</div>`
           : this.events.length === 0
-            ? html`<div class="status-fallback">[ no recent activity ]</div>`
+            ? html`<div class="status-fallback" role="status" aria-live="polite">[ no recent activity ]</div>`
             : html`<div role="list">
-              ${this.events.map(e => html`
+              ${this.events.map((e) => {
+                const type = normalizeEventType(e.type);
+                const message = displayEventMessage(e.message);
+                return html`
                 <div class="row" role="listitem">
-                  <span class="row-name"><span class="tag">[${e.type}]</span> ${e.repo}: ${e.message}</span>
+                  <span class="row-name"><span class="tag">[${type}]</span> ${e.repo}: ${message}</span>
                   <span class="row-meta">${relativeTime(e.timestamp)}</span>
                 </div>
-              `)}
+              `;
+              })}
             </div>`}
     `;
   }

--- a/src/clanka-activity.ts
+++ b/src/clanka-activity.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { displayEventMessage, fetchEvents, normalizeEventType, relativeTime } from './time-utils';
+import { displayEventMessage, normalizeEventType } from './event-display';
+import { fetchEvents, relativeTime } from './time-utils';
 import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { displayEventMessage, fetchEvents, normalizeEventType, relativeTime } from './time-utils';
+import { displayEventMessage, normalizeEventType } from './event-display';
+import { fetchEvents, relativeTime } from './time-utils';
 import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };

--- a/src/clanka-terminal.ts
+++ b/src/clanka-terminal.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { fetchEvents, relativeTime } from './time-utils';
+import { displayEventMessage, fetchEvents, normalizeEventType, relativeTime } from './time-utils';
 import { withResultRetries } from './retry';
 
 type EventItem = { type: string; repo: string; message: string; timestamp: string };
@@ -123,17 +123,21 @@ export class ClankaTerminal extends LitElement {
         <span class="sec-label">terminal</span>
         <div class="sec-line"></div>
       </div>
-      <div class="terminal" role="log" aria-label="Terminal output">
+      <div class="terminal" role="log" aria-label="Terminal output" aria-busy=${this.loading ? 'true' : 'false'}>
         <div class="line prompt">clanka@fleet:~$ git log --oneline --all-repos</div>
         ${this.loading
           ? html`<div class="line dim">[ fetching activity... ]<span class="cursor"></span></div>`
           : this.error
-            ? html`<div class="line dim">${this.error}</div>`
+            ? html`<div class="line dim" role="status" aria-live="polite">${this.error}</div>`
             : this.events.length === 0
-              ? html`<div class="line dim">[ no recent activity ]</div>`
-              : this.events.map(e => html`
-              <div class="line"><span class="tag">[${e.type}]</span> <span class="repo">${e.repo}:</span> <span class="msg">"${e.message}"</span>  <span class="ts">· ${relativeTime(e.timestamp)}</span></div>
-            `)}
+              ? html`<div class="line dim" role="status" aria-live="polite">[ no recent activity ]</div>`
+              : this.events.map((e) => {
+                  const type = normalizeEventType(e.type);
+                  const message = displayEventMessage(e.message);
+                  return html`
+              <div class="line"><span class="tag">[${type}]</span> <span class="repo">${e.repo}:</span> <span class="msg">"${message}"</span>  <span class="ts">· ${relativeTime(e.timestamp)}</span></div>
+            `;
+                })}
         ${!this.loading ? html`<div class="line prompt">clanka@fleet:~$ <span class="cursor"></span></div>` : ''}
       </div>
     `;

--- a/src/event-display.ts
+++ b/src/event-display.ts
@@ -1,0 +1,18 @@
+/** Normalize live API short types and *Event names for terminal/activity tags. */
+export function normalizeEventType(type: string): string {
+  const raw = type.trim();
+  if (!raw) return 'push';
+
+  const upper = raw.toUpperCase();
+  if (upper === 'PR' || upper === 'PULL_REQUEST' || upper === 'PULLREQUESTEVENT') return 'pr';
+  if (upper === 'CREATE' || upper === 'CREATEEVENT') return 'create';
+  if (upper === 'PUSH' || upper === 'PUSHEVENT') return 'push';
+
+  return raw.replace(/Event$/i, '').toLowerCase() || 'push';
+}
+
+/** Blank event messages should not render as empty quotes. */
+export function displayEventMessage(message: string): string {
+  const trimmed = message.trim();
+  return trimmed.length > 0 ? trimmed : '—';
+}

--- a/src/time-utils.ts
+++ b/src/time-utils.ts
@@ -12,6 +12,25 @@ export function relativeTime(iso: string): string {
   return `${Math.floor(ms / 86_400_000)}d ago`;
 }
 
+/** Normalize live API short types and *Event names for terminal/activity tags. */
+export function normalizeEventType(type: string): string {
+  const raw = type.trim();
+  if (!raw) return 'push';
+
+  const upper = raw.toUpperCase();
+  if (upper === 'PR' || upper === 'PULL_REQUEST' || upper === 'PULLREQUESTEVENT') return 'pr';
+  if (upper === 'CREATE' || upper === 'CREATEEVENT') return 'create';
+  if (upper === 'PUSH' || upper === 'PUSHEVENT') return 'push';
+
+  return raw.replace(/Event$/i, '').toLowerCase() || 'push';
+}
+
+/** Blank event messages should not render as empty quotes. */
+export function displayEventMessage(message: string): string {
+  const trimmed = message.trim();
+  return trimmed.length > 0 ? trimmed : '—';
+}
+
 export async function fetchEvents(): Promise<GithubEventsResult> {
   return fetchGithubEvents();
 }

--- a/src/time-utils.ts
+++ b/src/time-utils.ts
@@ -12,25 +12,6 @@ export function relativeTime(iso: string): string {
   return `${Math.floor(ms / 86_400_000)}d ago`;
 }
 
-/** Normalize live API short types and *Event names for terminal/activity tags. */
-export function normalizeEventType(type: string): string {
-  const raw = type.trim();
-  if (!raw) return 'push';
-
-  const upper = raw.toUpperCase();
-  if (upper === 'PR' || upper === 'PULL_REQUEST' || upper === 'PULLREQUESTEVENT') return 'pr';
-  if (upper === 'CREATE' || upper === 'CREATEEVENT') return 'create';
-  if (upper === 'PUSH' || upper === 'PUSHEVENT') return 'push';
-
-  return raw.replace(/Event$/i, '').toLowerCase() || 'push';
-}
-
-/** Blank event messages should not render as empty quotes. */
-export function displayEventMessage(message: string): string {
-  const trimmed = message.trim();
-  return trimmed.length > 0 ? trimmed : '—';
-}
-
 export async function fetchEvents(): Promise<GithubEventsResult> {
   return fetchGithubEvents();
 }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -215,6 +215,39 @@ test('fleet hides status pill when API omits online state', async ({ page }) => 
   await expect(fleet.locator('.sync.synced')).toBeVisible();
 });
 
+test('terminal normalizes event types and blank messages', async ({ page }) => {
+  await page.route(`${API_BASE}/github/events`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        events: [
+          {
+            type: 'PR',
+            repo: 'clankamode/site',
+            message: '   ',
+            timestamp: '2026-03-03T03:40:00.000Z',
+          },
+          {
+            type: 'PUSH',
+            repo: 'clankamode/api',
+            message: 'ship it',
+            timestamp: '2026-03-03T03:41:00.000Z',
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  const terminal = page.locator('clanka-terminal#terminal');
+  await terminal.scrollIntoViewIfNeeded();
+  await expect(terminal.locator('.tag').first()).toHaveText('[pr]');
+  await expect(terminal.locator('.msg').first()).toHaveText('"—"');
+  await expect(terminal.locator('.tag').nth(1)).toHaveText('[push]');
+  await expect(terminal.locator('.terminal')).toHaveAttribute('aria-busy', 'false');
+});
+
 test('malformed github events show unavailable instead of empty activity', async ({ page }) => {
   await page.route(`${API_BASE}/github/events`, async (route) => {
     await route.fulfill({

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -357,6 +357,19 @@ test('parseNowPayload rejects invalid shapes and preserves optional fields', asy
   );
 });
 
+test('event display helpers normalize types and blank messages', async () => {
+  const { normalizeEventType, displayEventMessage } = await loadTsModule('src/time-utils.ts');
+
+  assert.equal(normalizeEventType('PUSH'), 'push');
+  assert.equal(normalizeEventType('PushEvent'), 'push');
+  assert.equal(normalizeEventType('PR'), 'pr');
+  assert.equal(normalizeEventType('CREATE'), 'create');
+  assert.equal(normalizeEventType(''), 'push');
+  assert.equal(displayEventMessage('  feat: x  '), 'feat: x');
+  assert.equal(displayEventMessage('   '), '—');
+  assert.equal(displayEventMessage(''), '—');
+});
+
 test('withRetries eventually succeeds and withResultRetries stops on ok', async () => {
   const { withRetries, withResultRetries } = await loadTsModule('src/retry.ts');
 

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -358,7 +358,7 @@ test('parseNowPayload rejects invalid shapes and preserves optional fields', asy
 });
 
 test('event display helpers normalize types and blank messages', async () => {
-  const { normalizeEventType, displayEventMessage } = await loadTsModule('src/time-utils.ts');
+  const { normalizeEventType, displayEventMessage } = await loadTsModule('src/event-display.ts');
 
   assert.equal(normalizeEventType('PUSH'), 'push');
   assert.equal(normalizeEventType('PushEvent'), 'push');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Centralizes event type normalization and blank-message fallbacks in `event-display.ts` (safe for content-test imports).
- Terminal and activity widgets show short, honest type tags (`pr`/`push`/`create`/…) and `—` instead of empty message cells.
- Adds `aria-live` / `aria-busy` so loading and offline updates are announced.

## Test plan
- [x] `npm run verify`
- [x] Content tests for `normalizeEventType` / `displayEventMessage`
- [x] Playwright asserts short type tags and blank-message fallback on mocked `/github/events`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

