### PR TITLE
Pause presence /now polling while the tab is hidden

### DIFF
--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -13,6 +13,14 @@ export class ClankaPresence extends LitElement {
   private pollId?: number;
   private hasSyncedOnce = false;
   private updateInFlight = false;
+  private onVisibility = (): void => {
+    if (document.hidden) {
+      this.stopPolling();
+      return;
+    }
+    this.ensurePolling();
+    void this.updatePresence();
+  };
 
   static styles = css`
     :host {
@@ -103,23 +111,34 @@ export class ClankaPresence extends LitElement {
     if (!this.hasAttribute('tabindex')) {
       this.tabIndex = 0;
     }
+    document.addEventListener('visibilitychange', this.onVisibility);
     // firstUpdated only runs once per instance — reconnect must re-arm polling
     // and refresh so a mid-flight disconnect cannot leave the widget stuck.
-    this.ensurePolling();
     void this.updatePresence();
+    if (!document.hidden) {
+      this.ensurePolling();
+    }
   }
 
   disconnectedCallback(): void {
-    if (this.pollId) {
-      window.clearInterval(this.pollId);
-      this.pollId = undefined;
-    }
+    document.removeEventListener('visibilitychange', this.onVisibility);
+    this.stopPolling();
     super.disconnectedCallback();
   }
 
   private ensurePolling(): void {
     if (this.pollId !== undefined) return;
-    this.pollId = window.setInterval(() => void this.updatePresence(), 30000);
+    this.pollId = window.setInterval(() => {
+      if (document.hidden) return;
+      void this.updatePresence();
+    }, 30000);
+  }
+
+  private stopPolling(): void {
+    if (this.pollId !== undefined) {
+      window.clearInterval(this.pollId);
+      this.pollId = undefined;
+    }
   }
 
   async updatePresence() {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -442,6 +442,8 @@ test('presence pauses polling while the tab is hidden', async ({ page }) => {
     });
   });
 
+  // Mock timers + Date so we can expire the /now TTL cache and the 30s poll.
+  await page.clock.install();
   await page.goto('/');
   await expect(page.locator('clanka-presence#presence')).toBeVisible();
   await expect.poll(() => nowHits).toBeGreaterThan(0);
@@ -451,13 +453,15 @@ test('presence pauses polling while the tab is hidden', async ({ page }) => {
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
     document.dispatchEvent(new Event('visibilitychange'));
   });
-  await page.waitForTimeout(500);
+  // Past poll interval + response TTL while hidden — polling must stay stopped.
+  await page.clock.fastForward(35_000);
   expect(nowHits).toBe(hitsAfterLoad);
 
   await page.evaluate(() => {
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
     document.dispatchEvent(new Event('visibilitychange'));
   });
+  // Visibility restore refreshes immediately; TTL is already expired so it hits the network.
   await expect.poll(() => nowHits).toBeGreaterThan(hitsAfterLoad);
 });
 

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -426,6 +426,41 @@ test('transient sync-error after a successful sync keeps task boards visible', a
   await expect(page.locator('#status-live-label')).toHaveText('STALE');
 });
 
+
+test('presence pauses polling while the tab is hidden', async ({ page }) => {
+  let nowHits = 0;
+  await page.route(`${API_BASE}/now`, async (route) => {
+    nowHits += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'shipping',
+        status: 'operational',
+        agents_active: 1,
+      }),
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('clanka-presence#presence')).toBeVisible();
+  await expect.poll(() => nowHits).toBeGreaterThan(0);
+  const hitsAfterLoad = nowHits;
+
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.waitForTimeout(500);
+  expect(nowHits).toBe(hitsAfterLoad);
+
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await expect.poll(() => nowHits).toBeGreaterThan(hitsAfterLoad);
+});
+
 test('presence announces status via aria-live and rejects blank current', async ({ page }) => {
   await page.route(`${API_BASE}/now`, async (route) => {
     await route.fulfill({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stops the presence widget’s 30s `/now` interval when `document.hidden`.
- Refreshes once and resumes polling when the tab becomes visible again.
- Keeps reconnect behavior intact: disconnect still clears the interval; reconnect re-arms only when visible.

## Test plan
- [x] `npm run verify` (rebased onto latest main)
- [x] Playwright: with mocked timers, a hidden tab does not poll past the interval/TTL; becoming visible triggers a network refresh
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

