### PR TITLE
Show agents_active when the team roster is empty

### DIFF
--- a/src/clanka-agents.ts
+++ b/src/clanka-agents.ts
@@ -4,6 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 @customElement('clanka-agents')
 export class ClankaAgents extends LitElement {
   @property({ attribute: false }) team: Record<string, unknown> = {};
+  @property({ type: Number }) agentsActive: number | null = null;
   @property({ type: Boolean }) loading = true;
   @property({ type: String }) error = '';
 
@@ -53,22 +54,29 @@ export class ClankaAgents extends LitElement {
 
   render() {
     const teamCount = this.teamCount;
+    const active =
+      typeof this.agentsActive === 'number' && Number.isFinite(this.agentsActive)
+        ? Math.max(0, Math.floor(this.agentsActive))
+        : null;
 
     return html`
       <div class="sec-header">
         <span class="sec-label">agents</span>
         <div class="sec-line"></div>
       </div>
-      <div class="note">
+      <div class="note" aria-live="polite">
         ${this.loading
           ? html`<span class="loading">[ loading... ]</span>`
           : this.error
             ? html`<span class="error">${this.error}</span>`
             : teamCount > 0
-              ? html`// team: ${teamCount} member${teamCount === 1 ? '' : 's'}<br>
+              ? html`// team: ${teamCount} member${teamCount === 1 ? '' : 's'}${active !== null ? html`<br>// ${active} active` : ''}<br>
                   // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`
-              : html`// agent orchestration is internal<br>
-                  // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`}
+              : active !== null && active > 0
+                ? html`// ${active} active · roster unavailable<br>
+                    // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`
+                : html`// agent orchestration is internal<br>
+                    // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`}
       </div>
     `;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ const agents = document.getElementById('agents') as (HTMLElement & {
   loading?: boolean;
   error?: string;
   team?: Record<string, unknown>;
+  agentsActive?: number | null;
 }) | null;
 
 const setText = (id: string, value: string): void => {
@@ -90,6 +91,9 @@ if (presence) {
     }
 
     const activeAgents = resolveActiveAgents(data);
+    if (agents && activeAgents !== null) {
+      agents.agentsActive = activeAgents;
+    }
     if (activeAgents !== null) {
       setText('stat-active-agents', `agents: ${activeAgents} active`);
     } else {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -357,6 +357,27 @@ test('github events offline path coalesces retries across terminal and commit fe
   expect(eventsHits).toBeLessThanOrEqual(3);
 });
 
+test('agents widget shows agents_active when roster is empty', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'shipping',
+        status: 'operational',
+        agents_active: 3,
+        team: {},
+      }),
+    });
+  });
+
+  await page.goto('/');
+  const agents = page.locator('clanka-agents#agents');
+  await expect(agents).toBeVisible();
+  await expect(agents.locator('.note')).toContainText('3 active · roster unavailable');
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: 3 active');
+});
+
 test('partial /now payloads do not wipe tasks or agents', async ({ page }) => {
   await page.route(`${API_BASE}/now`, async (route) => {
     await route.fulfill({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Wires the resolved `/now` active-agent count into `clanka-agents`.
- When `team` is empty but `agents_active` is present, the panel shows `N active · roster unavailable` instead of the generic internal-orchestration copy.
- Adds `aria-live="polite"` on the agents note so status updates are announced.

## Test plan
- [x] `npm run verify` (rebased onto latest main)
- [x] Playwright: empty `team` + `agents_active: 3` renders honest active copy and matches the stat line
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

