### PR TITLE
fix(content): keep j/k out of focused audio player controls

### DIFF
--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -133,8 +133,18 @@
     if (which === 'prev') return links[0]?.getAttribute('href') || null;
     return links.length > 1 ? links[1].getAttribute('href') : null;
   };
+  const isTypingTarget = (target) => {
+    if (!(target instanceof Element)) return false;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return true;
+    if (target instanceof HTMLSelectElement || target instanceof HTMLButtonElement) return true;
+    if (target.isContentEditable) return true;
+    // Audio player controls (play/skip/speed/scrubber) must keep j/k/t local.
+    return Boolean(target.closest('.audio-player, a, button, [role="slider"]'));
+  };
+
   document.addEventListener('keydown', (e) => {
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTypingTarget(e.target)) return;
     if (e.key === 'j') {
       const next = resolveNavHref('next');
       if (next) window.location.href = next;
@@ -147,7 +157,8 @@
 
   // 4. Back to top on 't'
   document.addEventListener('keydown', (e) => {
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTypingTarget(e.target)) return;
     if (e.key === 't') {
       const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
         ? 'auto'

--- a/tests/audio-player.spec.ts
+++ b/tests/audio-player.spec.ts
@@ -205,3 +205,16 @@ test('skip -15s rewinds currentTime', async ({ page }) => {
   const t = await page.evaluate(() => (window as any).__mockAudio.currentTime);
   expect(t).toBe(35);
 });
+
+test('j/k post navigation does not fire while audio controls are focused', async ({ page }) => {
+  await page.waitForSelector('.post-nav a[data-nav], .post-nav-enhanced a[data-nav]');
+  const before = page.url();
+
+  await page.locator('.ap-progress-wrap').focus();
+  await page.keyboard.press('j');
+  await expect(page).toHaveURL(before);
+
+  await page.locator('.ap-play').focus();
+  await page.keyboard.press('k');
+  await expect(page).toHaveURL(before);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post `j`/`k` prev/next shortcuts fired even when focus was on audio player controls (scrubber, play, skip). That yanked listeners off the page mid-listen.

## Change

- Ignore `j`/`k`/`t` when focus is inside `.audio-player`, buttons, links, sliders, or other typing targets
- Also ignore when meta/ctrl/alt are held
- Playwright coverage for focused scrubber/play + `j`/`k`

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Focused: `npx playwright test tests/audio-player.spec.ts -g 'audio controls are focused'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

