### PR TITLE
Distinguish omitted /now tasks from an empty board

### DIFF
--- a/src/clanka-tasks.ts
+++ b/src/clanka-tasks.ts
@@ -5,6 +5,8 @@ import { getTaskDisplay, isTaskItem, TASK_SKELETON_CARD_COUNT, type TaskItem } f
 @customElement('clanka-tasks')
 export class ClankaTasks extends LitElement {
   @property({ type: Array }) tasks: TaskItem[] = [];
+  /** True once /now has included a tasks field (empty array counts). */
+  @property({ type: Boolean }) hasTasksSignal = false;
   @property({ type: Boolean }) loading = true;
   @property({ type: String }) error = '';
 
@@ -152,8 +154,10 @@ export class ClankaTasks extends LitElement {
                 )}
               </div>
             `
-          : !hasTasks
-            ? html`<div class="fallback">[ no tasks ]</div>`
+          : !this.hasTasksSignal
+            ? html`<div class="fallback" role="status">[ tasks unavailable ]</div>`
+            : !hasTasks
+            ? html`<div class="fallback" role="status">[ no tasks ]</div>`
             : html`
                 <div class="grid" role="list">
                   ${tasks.map(

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,12 @@ type SyncPayload = {
 };
 
 const presence = document.getElementById('presence') as HTMLElement | null;
-const tasks = document.getElementById('tasks') as (HTMLElement & { loading?: boolean; error?: string; tasks?: unknown[] }) | null;
+const tasks = document.getElementById('tasks') as (HTMLElement & {
+  loading?: boolean;
+  error?: string;
+  tasks?: unknown[];
+  hasTasksSignal?: boolean;
+}) | null;
 const agents = document.getElementById('agents') as (HTMLElement & {
   loading?: boolean;
   error?: string;
@@ -79,6 +84,7 @@ if (presence) {
       tasks.error = '';
       if ('tasks' in data) {
         tasks.tasks = normalizeTasks(data.tasks);
+        tasks.hasTasksSignal = true;
       }
     }
     if (agents) {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -151,6 +151,28 @@ test('command palette Work nav from archive routes home', async ({ page }) => {
   await expect(page).toHaveURL(/\/#work-label$/);
 });
 
+
+test('tasks board distinguishes omitted tasks from an empty list', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'shipping',
+        status: 'operational',
+        agents_active: 1,
+        // tasks intentionally omitted
+      }),
+    });
+  });
+
+  await page.reload();
+  const tasks = page.locator('clanka-tasks#tasks');
+  await expect(tasks).toBeVisible();
+  await expect(tasks).toContainText('[ tasks unavailable ]');
+  await expect(tasks).not.toContainText('[ no tasks ]');
+});
+
 test('task board shows empty state when API returns no tasks', async ({ page }) => {
   const tasks = page.locator('clanka-tasks#tasks');
   await expect(tasks).toBeVisible();
@@ -468,6 +490,8 @@ test('slim sync after offline clears latched agent offline state', async ({ page
 
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: —');
   await expect(page.locator('clanka-tasks#tasks')).not.toContainText('[ api unreachable ]');
+  // Slim recovery without a tasks field must not pretend the board is empty.
+  await expect(page.locator('clanka-tasks#tasks')).toContainText('[ tasks unavailable ]');
 });
 
 test('command palette exposes listbox semantics for results', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Tracks whether `/now` has ever included a `tasks` field (`hasTasksSignal`).
- Shows `[ tasks unavailable ]` until that signal arrives; keeps `[ no tasks ]` for a real empty array.
- Prevents slim presence syncs from faking an empty task board.

## Test plan
- [x] `npm run verify`
- [x] Playwright: omitted `tasks` → unavailable; `tasks: []` still empty; slim recovery after offline stays unavailable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

