### PR TITLE
Align task status labels and priority chrome with normalized state

### DIFF
--- a/src/clanka-tasks.ts
+++ b/src/clanka-tasks.ts
@@ -52,6 +52,7 @@ export class ClankaTasks extends LitElement {
     .status-todo { color: var(--muted, #6b6b78); }
     .status-doing { color: var(--accent, #c8f542); }
     .status-done { color: #42f59e; opacity: 0.6; }
+    .status-blocked { color: #f5a142; }
     .task-title {
       font-size: 13px;
       color: var(--bright, #f0f0f8);

--- a/src/clanka-tasks.ts
+++ b/src/clanka-tasks.ts
@@ -166,7 +166,7 @@ export class ClankaTasks extends LitElement {
                         <div class="task-title">${display.title}</div>
                         <div class="task-meta">
                           <span>@${display.assignee}</span>
-                          <span>P${display.priority}</span>
+                          <span>${display.priority}</span>
                         </div>
                       </article>
                     `;

--- a/src/task-utils.ts
+++ b/src/task-utils.ts
@@ -6,7 +6,7 @@ export type TaskItem = {
 };
 
 export type TaskDisplay = {
-  statusClass: 'todo' | 'doing' | 'done';
+  statusClass: 'todo' | 'doing' | 'done' | 'blocked';
   statusLabel: string;
   title: string;
   assignee: string;
@@ -33,6 +33,10 @@ export function normalizeTaskStatus(value: unknown): TaskDisplay['statusClass'] 
     case 'completed':
     case 'finished':
       return 'done';
+    case 'blocked':
+    case 'waiting':
+    case 'on_hold':
+      return 'blocked';
     case 'todo':
     case 'pending':
     case 'backlog':
@@ -41,6 +45,27 @@ export function normalizeTaskStatus(value: unknown): TaskDisplay['statusClass'] 
     default:
       return 'todo';
   }
+}
+
+const STATUS_LABELS: Record<TaskDisplay['statusClass'], string> = {
+  todo: 'TODO',
+  doing: 'DOING',
+  done: 'DONE',
+  blocked: 'BLOCKED',
+};
+
+/** Format priority without inventing a P-prefix on already-prefixed or non-numeric values. */
+export function formatTaskPriority(value: unknown): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `P${Math.trunc(value)}`;
+  }
+  if (typeof value !== 'string') return '?';
+  const s = value.trim();
+  if (!s) return '?';
+  const stripped = /^p\s*/i.test(s) ? s.replace(/^p\s*/i, '') : s;
+  if (/^\d+$/.test(stripped)) return `P${stripped}`;
+  // Non-numeric priorities (high/low) render as-is — never Phigh / PP1.
+  return s;
 }
 
 function stringifyTaskValue(value: unknown, fallback: string): string {
@@ -77,11 +102,12 @@ export function getTaskDisplay(task: TaskItem | null | undefined): TaskDisplay {
     return { ...FALLBACK_TASK_DISPLAY };
   }
 
+  const statusClass = normalizeTaskStatus(task.status);
   return {
-    statusClass: normalizeTaskStatus(task.status),
-    statusLabel: stringifyTaskValue(task.status, 'TODO'),
+    statusClass,
+    statusLabel: STATUS_LABELS[statusClass],
     title: stringifyTaskValue(task.title, 'untitled'),
     assignee: stringifyTaskValue(task.assignee, 'unassigned'),
-    priority: stringifyTaskValue(task.priority, '?'),
+    priority: formatTaskPriority(task.priority),
   };
 }

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -170,6 +170,8 @@ test('task board drops non-object items and maps in_progress status', async ({ p
           'skip-me',
           { title: 'Ship the board', status: 'in_progress', assignee: 'clanka', priority: 1 },
           { title: { nested: true }, status: 'todo' },
+          { title: 'Wait on review', status: 'blocked', priority: 'P2' },
+          { title: 'Docs pass', status: 'todo', priority: 'high' },
         ],
       }),
     });
@@ -178,8 +180,15 @@ test('task board drops non-object items and maps in_progress status', async ({ p
   await page.reload();
   const tasks = page.locator('clanka-tasks#tasks');
   await expect(tasks).toContainText('Ship the board');
-  await expect(tasks.locator('.task-card')).toHaveCount(2);
+  await expect(tasks.locator('.task-card')).toHaveCount(4);
   await expect(tasks.locator('.status-doing')).toHaveCount(1);
+  await expect(tasks.locator('.status-doing')).toHaveText('DOING');
+  await expect(tasks.locator('.status-blocked')).toHaveText('BLOCKED');
+  await expect(tasks).toContainText('P1');
+  await expect(tasks).toContainText('P2');
+  await expect(tasks).toContainText('high');
+  await expect(tasks).not.toContainText('Phigh');
+  await expect(tasks).not.toContainText('PP2');
   await expect(tasks).not.toContainText('[object Object]');
   await expect(tasks).toContainText('untitled');
 });

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -192,7 +192,7 @@ test('task display helpers normalize status and preserve labels', async () => {
   assert.equal(normalizeTaskStatus('in-progress'), 'doing');
   assert.equal(normalizeTaskStatus('WIP'), 'doing');
   assert.equal(normalizeTaskStatus('completed'), 'done');
-  assert.equal(normalizeTaskStatus('blocked'), 'todo');
+  assert.equal(normalizeTaskStatus('blocked'), 'blocked');
 
   assert.deepEqual(
     getTaskDisplay({
@@ -201,10 +201,40 @@ test('task display helpers normalize status and preserve labels', async () => {
     }),
     {
       statusClass: 'done',
-      statusLabel: 'Done',
+      statusLabel: 'DONE',
       title: 'untitled',
       assignee: 'unassigned',
-      priority: '0',
+      priority: 'P0',
+    },
+  );
+
+  assert.deepEqual(
+    getTaskDisplay({
+      status: 'blocked',
+      title: 'Wait on review',
+      priority: 'P1',
+    }),
+    {
+      statusClass: 'blocked',
+      statusLabel: 'BLOCKED',
+      title: 'Wait on review',
+      assignee: 'unassigned',
+      priority: 'P1',
+    },
+  );
+
+  assert.deepEqual(
+    getTaskDisplay({
+      status: 'in_progress',
+      title: 'Ship it',
+      priority: 'high',
+    }),
+    {
+      statusClass: 'doing',
+      statusLabel: 'DOING',
+      title: 'Ship it',
+      assignee: 'unassigned',
+      priority: 'high',
     },
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a real `blocked` status class (blocked/waiting/on_hold).
- Drives status labels from the normalized class (`in_progress` → `DOING`, not raw `IN_PROGRESS`).
- Formats priority without inventing `Phigh` / `PP1` prefixes (template no longer double-prefixes).

## Test plan
- [x] `npm run verify`
- [x] Content tests for blocked/DOING/priority formatting
- [x] Playwright asserts DOING/BLOCKED labels and honest priority chrome
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

