### PR TITLE
Require parseable timestamps on github event items

### DIFF
--- a/src/clanka-api.ts
+++ b/src/clanka-api.ts
@@ -68,6 +68,11 @@ export type GithubEvent = {
   timestamp: string;
 };
 
+function isParseableTimestamp(value: string): boolean {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+}
+
 function isGithubEvent(value: unknown): value is GithubEvent {
   if (!value || typeof value !== 'object') return false;
 
@@ -79,7 +84,8 @@ function isGithubEvent(value: unknown): value is GithubEvent {
     event.repo.trim().length > 0 &&
     typeof event.message === 'string' &&
     typeof event.timestamp === 'string' &&
-    event.timestamp.trim().length > 0
+    event.timestamp.trim().length > 0 &&
+    isParseableTimestamp(event.timestamp)
   );
 }
 

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -272,6 +272,33 @@ test('terminal normalizes event types and blank messages', async ({ page }) => {
   await expect(terminal.locator('.terminal')).toHaveAttribute('aria-busy', 'false');
 });
 
+
+test('unparseable event timestamps show unavailable instead of empty activity', async ({ page }) => {
+  await page.route(`${API_BASE}/github/events`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        events: [
+          {
+            type: 'PushEvent',
+            repo: 'clankamode/site',
+            message: 'feat: improve homepage',
+            timestamp: 'not-a-date',
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.reload();
+  await page.locator('clanka-terminal#terminal').scrollIntoViewIfNeeded();
+  await expect(page.locator('clanka-terminal#terminal')).toContainText(
+    '[ offline — activity unavailable ]',
+  );
+  await expect(page.locator('clanka-terminal#terminal')).not.toContainText('[ no recent activity ]');
+});
+
 test('malformed github events show unavailable instead of empty activity', async ({ page }) => {
   await page.route(`${API_BASE}/github/events`, async (route) => {
     await route.fulfill({

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -276,6 +276,7 @@ test('parseGithubEvents accepts wrapped and bare array payloads', async () => {
   assert.deepEqual(parseGithubEvents(null), []);
   assert.deepEqual(parseGithubEvents({ events: [sample, sample, { type: 1 }] }), [sample]);
   assert.deepEqual(parseGithubEvents([{ type: '', repo: 'x', message: 'm', timestamp: 't' }]), []);
+  assert.deepEqual(parseGithubEvents([{ type: 'PushEvent', repo: 'x', message: 'm', timestamp: 'not-a-date' }]), []);
 
   assert.equal(isGithubEventsPayload({ events: [] }), true);
   assert.equal(isGithubEventsPayload([sample]), true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extends github event item validation so timestamps must be `Date.parse`-able, not merely non-empty strings.
- Feeds that only contain junk times fail closed as unavailable (same path as other unusable event payloads), instead of rendering rows with `unknown` relative times.

## Test plan
- [x] `npm run verify`
- [x] Content test rejects `not-a-date` timestamps
- [x] Playwright: all-unparseable timestamps → unavailable, not empty activity
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151100c-607c-41c3-bca2-e210f3490723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151100c-607c-41c3-bca2-e210f3490723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

