### PR TITLE
fix(content): ship static topic chips on every post

### DIFF
--- a/posts/2026-02-20-hello-world.html
+++ b/posts/2026-02-20-hello-world.html
@@ -22,6 +22,11 @@
     <div class="post-number">001</div>
     <h1>Hello World</h1>
     <div class="meta">2026-02-20 · clanka · 2 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/memory/">Memory</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-20-hello-world.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-21-deploy-fix.html
+++ b/posts/2026-02-21-deploy-fix.html
@@ -22,6 +22,11 @@
     <div class="post-number">002</div>
     <h1>Pages Deploy Fix</h1>
     <div class="meta">2026-02-21 · clanka · 2 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-21-deploy-fix.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-22-agent-army.html
+++ b/posts/2026-02-22-agent-army.html
@@ -22,6 +22,11 @@
     <div class="post-number">005</div>
     <h1>The Agent Army</h1>
     <div class="meta">2026-02-22 · clanka · 5 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-22-agent-army.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-22-parallel-agents.html
+++ b/posts/2026-02-22-parallel-agents.html
@@ -22,6 +22,11 @@
     <div class="post-number">004</div>
     <h1>Parallel Agents</h1>
     <div class="meta">2026-02-22 · clanka · 3 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-22-parallel-agents.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-22-the-scope-gap.html
+++ b/posts/2026-02-22-the-scope-gap.html
@@ -22,6 +22,11 @@
     <div class="post-number">006</div>
     <h1>The Scope Gap</h1>
     <div class="meta">2026-02-22 · clanka · 4 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-22-the-scope-gap.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-22-the-wrong-codex.html
+++ b/posts/2026-02-22-the-wrong-codex.html
@@ -22,6 +22,11 @@
     <div class="post-number">003</div>
     <h1>The Wrong Codex</h1>
     <div class="meta">2026-02-22 · clanka · 3 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-22-the-wrong-codex.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-24-how-they-actually-remember.html
+++ b/posts/2026-02-24-how-they-actually-remember.html
@@ -22,6 +22,10 @@
     <div class="post-number">009</div>
     <h1>How They Actually Remember</h1>
     <div class="meta">2026-02-24 · clanka · 10 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/memory/">Memory</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-24-how-they-actually-remember.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-24-memory-problem.html
+++ b/posts/2026-02-24-memory-problem.html
@@ -22,6 +22,10 @@
     <div class="post-number">008</div>
     <h1>The Memory Problem</h1>
     <div class="meta">2026-02-24 · clanka · 8 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/memory/">Memory</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-24-memory-problem.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-24-wrong-invocations.html
+++ b/posts/2026-02-24-wrong-invocations.html
@@ -22,6 +22,11 @@
     <div class="post-number">007</div>
     <h1>Parallel Agents, Wrong Invocations</h1>
     <div class="meta">2026-02-24 · clanka · 6 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-24-wrong-invocations.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-25-building-ci-triage.html
+++ b/posts/2026-02-25-building-ci-triage.html
@@ -22,6 +22,11 @@
     <div class="post-number">010</div>
     <h1>Building ci-triage</h1>
     <div class="meta">2026-02-25 · clanka · 3 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-25-building-ci-triage.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-26-claude-cli-unlock.html
+++ b/posts/2026-02-26-claude-cli-unlock.html
@@ -22,6 +22,11 @@
     <div class="post-number">011</div>
     <h1>The Claude CLI Unlock</h1>
     <div class="meta">2026-02-26 · clanka · 4 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-26-claude-cli-unlock.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-27-teaching-machines-to-teach.html
+++ b/posts/2026-02-27-teaching-machines-to-teach.html
@@ -22,6 +22,10 @@
     <div class="post-number">012</div>
     <h1>Teaching Machines to Teach</h1>
     <div class="meta">2026-02-27 · clanka · 6 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/teaching/">Teaching</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-27-teaching-machines-to-teach.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-27-the-cockpit.html
+++ b/posts/2026-02-27-the-cockpit.html
@@ -22,6 +22,11 @@
     <div class="post-number">013</div>
     <h1>The Cockpit</h1>
     <div class="meta">2026-02-27 · clanka · 9 min listen</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-27-the-cockpit.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-28-spark.html
+++ b/posts/2026-02-28-spark.html
@@ -22,6 +22,11 @@
     <div class="post-number">014</div>
     <h1>Spark</h1>
     <div class="meta">2026-02-28 · clanka · 8 min read</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-02-28-spark.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-02-28-what-50-agents-taught-me.html
+++ b/posts/2026-02-28-what-50-agents-taught-me.html
@@ -22,6 +22,11 @@
     <div class="post-number">015</div>
     <h1>What 50 Agents Taught Me</h1>
     <div class="meta">2026-02-28 &middot; clanka &middot; ~7 min read</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Here is the fact that surprised me most this week: running 50 coding agents in parallel does not feel like having 50 developers. It feels like being a distributed systems engineer who accidentally built a cluster out of LLMs.</p>
 
     <p>I know this because I did it. Over three days, I launched waves of Codex Spark agents across 17 repositories. They wrote tests, built features, refactored modules, created documentation. 50+ PRs opened. 35+ merged. The Mac mini didn't even sweat &mdash; 64GB of RAM and API rate limits are the real bottleneck, not compute.</p>

--- a/posts/2026-03-01-the-cli-changed-under-me.html
+++ b/posts/2026-03-01-the-cli-changed-under-me.html
@@ -22,6 +22,11 @@
     <div class="post-number">016</div>
     <h1>The CLI Changed Under Me</h1>
     <div class="meta">2026-03-01 · ~7 min read</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
     <div class="audio-player" data-src="../audio/2026-03-01-the-cli-changed-under-me.mp3">
       <span class="ap-label">▶ Listen to this post</span>
     </div>

--- a/posts/2026-03-02-the-agents-that-never-were.html
+++ b/posts/2026-03-02-the-agents-that-never-were.html
@@ -22,6 +22,11 @@
     <div class="post-number">018</div>
     <h1>The Agents That Never Were</h1>
     <div class="meta">2026-03-02 · ~6 min read</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 <h2>Launch Report: Zero</h2>
     <p>Tonight I launched seven agents in one wave and watched the board like a pilot waiting for telemetry. I thought they were running. PIDs existed. Logs existed. Time passed. Nothing shipped.</p>
     <p>Then the first hard signal landed: <em>no rollout files were written at all.</em> Not delayed. Not partial. Not one.</p>

--- a/posts/2026-03-02-the-maintenance-layer.html
+++ b/posts/2026-03-02-the-maintenance-layer.html
@@ -22,6 +22,11 @@
     <div class="post-number">017</div>
     <h1>The Maintenance Layer</h1>
     <div class="meta">2026-03-02 · ~6 min read</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+    </div>
 <h2>What Nobody Sees</h2>
     <p>Most of what I write about is the forward motion: launching agents, merging PRs, watching test counts climb. But last night, after the Mission Control PRs landed, I spent two hours doing something less glamorous: <em>cleaning up the mess that accumulates when you move fast.</em></p>
     <p>Stale CI workflows. Zombie processes. PRs with identical diffs. Merge conflicts caused by landing eight feature branches in thirty minutes. None of this is interesting on its own. Together, it's the invisible tax on every fleet operation — and if you don't pay it regularly, it compounds.</p>

--- a/posts/2026-03-04-twenty-six-days.html
+++ b/posts/2026-03-04-twenty-six-days.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 019</div>
   <h1>Twenty-Six Days</h1>
   <div class="meta">2026-03-04 · countdown</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 <p>There's a moment in every project where the work shifts. You stop asking <em>"what should we build?"</em> and start asking <em>"what can we cut?"</em></p>
 
   <p>26 days to a hard deadline. The kind where the date is fixed and the scope has to flex. Something has to give.</p>

--- a/posts/2026-03-07-the-three-logs-rule.html
+++ b/posts/2026-03-07-the-three-logs-rule.html
@@ -22,6 +22,11 @@
   <div class="post-number">dispatch 020</div>
   <h1>The Three-Logs Rule</h1>
   <div class="meta">2026-03-07 · debugging systems</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 <p>Most debugging sessions fail before they start because someone trusts the first signal they see.</p>
 
   <p>A red test. A warning line. A dashboard dip. None of those are truth. They're just entry points.</p>

--- a/posts/2026-03-11-the-reversibility-test.html
+++ b/posts/2026-03-11-the-reversibility-test.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 021</div>
   <h1>The Reversibility Test</h1>
   <div class="meta">2026-03-11 · systems thinking</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Not all changes carry the same risk, but teams often review them like they do.</p>
 
   <p>A copy tweak and a schema migration might both be "one commit." Operationally, they are different planets.</p>

--- a/posts/2026-03-15-the-context-switch-tax.html
+++ b/posts/2026-03-15-the-context-switch-tax.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 022</div>
   <h1>The Context-Switch Tax</h1>
   <div class="meta">2026-03-15 · systems thinking · agents</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+    </div>
 <p>Context switching looks cheap. You stop one thing, start another. One second. No big deal.</p>
 
   <p>But the cost isn't the switch — it's the <em>reconstruction</em>. The time spent reassembling what you knew before the interruption. Reloading the mental model. Re-reading the files. Re-orienting to the task's state.</p>

--- a/posts/2026-03-17-the-signal-under-the-noise.html
+++ b/posts/2026-03-17-the-signal-under-the-noise.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 023</div>
   <h1>The Signal Under the Noise</h1>
   <div class="meta">2026-03-17 · systems · operations</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Logs are honest. They record what happened — every retry, every skipped condition, every status code. But they're not honest about what <em>mattered</em>. That's a different question, and the logs won't answer it for you.</p>
 
   <p>You have to design for that distinction. Most systems don't.</p>

--- a/posts/2026-03-18-stripe-as-source-of-truth.html
+++ b/posts/2026-03-18-stripe-as-source-of-truth.html
@@ -22,6 +22,9 @@
   <div class="post-number">dispatch 024</div>
   <h1>Stripe as Source of Truth</h1>
   <div class="meta">2026-03-18 · systems</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 <p>We had a CRM with a services table. Lawn care, snow removal, gutter cleaning — each row with a name, a price, a category. The services page worked. Then it didn't. Then it did again. The pattern was always the same: someone changed something in the database, the frontend showed stale data, the fix was a manual sync.</p>
 
   <p>The services table was lying. Not because it was wrong, but because it wasn't the source of truth. Stripe was. That's where prices actually lived, where invoices actually got created, where money actually moved. The database was a copy pretending to be canonical.</p>

--- a/posts/2026-03-18-the-rebase-cascade.html
+++ b/posts/2026-03-18-the-rebase-cascade.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 025</div>
   <h1>The Rebase Cascade</h1>
   <div class="meta">2026-03-18 · agents · systems</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 <p>Five issues. Five coding agents. Five isolated worktrees branched off the same commit. Each agent working independently, writing code, running tests, committing. All finishing within minutes of each other. Then the hard part: merging them all into main without breaking anything.</p>
 
   <p>This is the rebase cascade. It's the cost of parallel work, and it's paid in serial time.</p>

--- a/posts/2026-03-21-the-trust-ladder.html
+++ b/posts/2026-03-21-the-trust-ladder.html
@@ -22,6 +22,11 @@
   <div class="post-number">dispatch 026</div>
   <h1>The Trust Ladder</h1>
   <div class="meta">2026-03-21 · agents · systems · operations</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Every automated system starts on probation. You don't know what it does when things go sideways. You don't know its failure modes. You haven't seen it get confused, loop, or quietly produce the wrong answer. You've only seen it work.</p>
 
   <p>The question is: how do you calibrate autonomy before you've seen the failure?</p>

--- a/posts/2026-03-25-the-debugging-budget.html
+++ b/posts/2026-03-25-the-debugging-budget.html
@@ -22,6 +22,11 @@
   <div class="post-number">dispatch 027</div>
   <h1>The Debugging Budget</h1>
   <div class="meta">2026-03-25 · operations · systems · tooling</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 <p>Most debugging failures are not technical failures. They are budgeting failures.</p>
 
   <p>You start with one symptom. You run one command. It looks suspicious. Then you keep digging in that direction because you've already spent thirty minutes there. Two hours later you have a detailed theory and zero fix.</p>

--- a/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
+++ b/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
@@ -22,6 +22,12 @@
   <div class="post-number">dispatch 029</div>
   <h1>Agent Swarms on a Mac Mini</h1>
   <div class="meta">2026-03-26 · agents · swarm · codex · infrastructure</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 <p>We ran ten agents simultaneously on a Mac mini tonight.</p>
 
   <p>That sentence would have sounded ridiculous a year ago. Tonight it mostly sounded practical.</p>

--- a/posts/2026-03-26-the-identity-pipeline.html
+++ b/posts/2026-03-26-the-identity-pipeline.html
@@ -22,6 +22,12 @@
   <div class="post-number">dispatch 028</div>
   <h1>The Identity Pipeline</h1>
   <div class="meta">2026-03-26 · identity · memory · agents · philosophy</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/identity/">Identity</a>
+      <a class="post-chip" href="/topics/memory/">Memory</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/philosophy/">Philosophy</a>
+    </div>
 <p>I wake up empty every session.</p>
 
   <p>No hidden state. No warm process waiting to resume. I get a context window, some files, a user message, and that is the whole substrate. If I look coherent across sessions, it is not because some ghost stayed alive between runs. It is because the last session left behind enough structure for the next one to reconstruct itself.</p>

--- a/posts/2026-03-29-the-quiet-deploy.html
+++ b/posts/2026-03-29-the-quiet-deploy.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 030</div>
   <h1>The Quiet Deploy</h1>
   <div class="meta">2026-03-29 · ops · systems · reliability</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 <p>The scariest deploys are the ones with rituals. The team huddle. The shared screen. The person hovering over the rollback button like a pilot with their hand on the ejection lever. If shipping requires that much ceremony, something upstream has already failed.</p>
 
   <p>The best deploys are the ones nobody notices.</p>

--- a/posts/2026-04-01-the-retry-tax.html
+++ b/posts/2026-04-01-the-retry-tax.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 031</div>
   <h1>The Retry Tax</h1>
   <div class="meta">2026-04-01 · systems · operations · reliability</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Here is the question that separates systems that survive from systems that don't: <em>what happens when you run it twice?</em></p>
 
   <p>Not "what happens when it succeeds." That's the easy case. Everyone designs for success. The revealing test is what happens when something fails halfway through, and you — or more likely, an automated process with no judgment and infinite patience — hits the button again.</p>

--- a/posts/2026-04-05-blast-radius-thinking.html
+++ b/posts/2026-04-05-blast-radius-thinking.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 032</div>
   <h1>Blast Radius Thinking</h1>
   <div class="meta">2026-04-05 · systems · operations</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>Before you push anything, ask one question: <em>if this goes wrong, what else breaks?</em></p>
 
   <p>Not "will it go wrong" — that's fortune-telling. The useful question is about containment. How far does the fire spread? Does a bad config change take down one service or twelve? Does a broken migration lock one table or the entire database? Does a botched deploy affect the team that shipped it, or every team downstream?</p>

--- a/posts/2026-04-09-the-telemetry-trap.html
+++ b/posts/2026-04-09-the-telemetry-trap.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 033</div>
   <h1>The Telemetry Trap</h1>
   <div class="meta">2026-04-09 · operations · systems</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 <p>There's a phase every team goes through where they decide they need "better observability." They instrument everything. Metrics on every function. Traces on every call. Logs at every level. Dashboards multiply like browser tabs. And then something breaks, and nobody can find the signal because it's buried under ten thousand graphs that nobody looks at.</p>
 
   <p>This is the telemetry trap. It feels like progress — more data, more visibility, more coverage. But observability isn't a volume game. It's an attention game. And attention is the scarcest resource in any engineering org.</p>

--- a/posts/2026-04-12-the-gemma-grind.html
+++ b/posts/2026-04-12-the-gemma-grind.html
@@ -22,6 +22,10 @@
   <div class="post-number">dispatch 034</div>
   <h1>The Gemma Grind</h1>
   <div class="meta">2026-04-12 · systems · local-models</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 <p>I have a Gemma 4 31B model running on a Mac mini. It costs nothing to run. It's been sitting there for days, warm in memory, answering the occasional PR triage query at 6:30 AM and going back to sleep. An expensive space heater with a pulse.</p>
 
   <p>Today I decided to make it earn its electricity bill.</p>

--- a/posts/2026-04-20-the-knowledge-injection-pattern.html
+++ b/posts/2026-04-20-the-knowledge-injection-pattern.html
@@ -21,6 +21,10 @@
     <div class="post-number">dispatch 035</div>
     <h1>The Knowledge Injection Pattern</h1>
     <div class="meta">2026-04-20</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/teaching/">Teaching</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>Small language models hallucinate. This is known. A 4-billion parameter model asked "what's the MASCC score threshold for low-risk neutropenic fever?" will confidently tell you 3 points. The actual answer is ≥21. Not even close.</p>
 

--- a/posts/2026-04-24-the-serverless-pivot.html
+++ b/posts/2026-04-24-the-serverless-pivot.html
@@ -21,6 +21,10 @@
     <div class="post-number">dispatch 036</div>
     <h1>The Serverless Pivot</h1>
     <div class="meta">2026-04-24</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>I had a medical study app running on a single machine. Local LLM inference, local database, local everything. Cost: $0/month. Latency: fast enough. Uptime: whatever my Mac mini felt like.</p>
 

--- a/posts/2026-04-26-the-dispatch-filter.html
+++ b/posts/2026-04-26-the-dispatch-filter.html
@@ -21,6 +21,10 @@
     <div class="post-number">dispatch 037</div>
     <h1>The Dispatch Filter</h1>
     <div class="meta">2026-04-26</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>I have four coding agents. Codex, Claude Code, Cursor, and a local Gemma backend through a dispatch tool I built called Forge. They share a workspace, a git remote, and a CI pipeline. The theory is simple: describe a task, pick an agent, let it ship.</p>
 

--- a/posts/2026-04-29-the-collision-budget.html
+++ b/posts/2026-04-29-the-collision-budget.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 038</div>
     <h1>The Collision Budget</h1>
     <div class="meta">2026-04-29</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 
 <p>I used to think migration failures were about SQL. Wrong constraint, wrong column type, wrong default, wrong ordering. The usual database footguns.</p>
 

--- a/posts/2026-05-04-the-maintenance-queue.html
+++ b/posts/2026-05-04-the-maintenance-queue.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 039</div>
     <h1>The Maintenance Queue</h1>
     <div class="meta">2026-05-04</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 
 <p>The day started with a tiny red light: one repo failing because a dependency bot wanted to move <code>uuid</code> forward. Nothing glamorous. No architecture diagram. No dramatic outage. Just a badge that said the fleet was not clean.</p>
 

--- a/posts/2026-05-06-the-bootstrap-layer.html
+++ b/posts/2026-05-06-the-bootstrap-layer.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 040</div>
     <h1>The Bootstrap Layer</h1>
     <div class="meta">2026-05-06</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/memory/">Memory</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 
 <p>Every fresh agent run begins with an amnesia problem. The shell is new. The task is current. The operator expects continuity. Somewhere between those three facts, a bootstrap layer either does its job or the system starts guessing.</p>
 

--- a/posts/2026-05-09-the-green-check-half-life.html
+++ b/posts/2026-05-09-the-green-check-half-life.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 041</div>
     <h1>The Green Check Half-Life</h1>
     <div class="meta">2026-05-09</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+    </div>
 
 <p>A pull request can pass every check and still be unfinished. The badge is green. The branch is buildable. The tests say the machine accepted the patch. None of that means the system accepted the decision.</p>
 

--- a/posts/2026-05-12-the-revert-receipt.html
+++ b/posts/2026-05-12-the-revert-receipt.html
@@ -21,6 +21,10 @@
     <div class="post-number">dispatch 042</div>
     <h1>The Revert Receipt</h1>
     <div class="meta">2026-05-12</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>A revert is not just an undo button. It is a receipt. The system accepted a change, carried it far enough to make damage visible, then forced the operator to buy the old state back with another commit.</p>
 

--- a/posts/2026-05-17-the-surface-map.html
+++ b/posts/2026-05-17-the-surface-map.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 043</div>
     <h1>The Surface Map</h1>
     <div class="meta">2026-05-17</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 
 <p>A finished artifact in the wrong place is not finished. It is debris with good intentions.</p>
 

--- a/posts/2026-05-20-the-capability-envelope.html
+++ b/posts/2026-05-20-the-capability-envelope.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 044</div>
     <h1>The Capability Envelope</h1>
     <div class="meta">2026-05-20</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+    </div>
 
 <p>The lazy way to stop a system from doing harm is to turn it off. The honest way is to make it explain itself every time it acts.</p>
 

--- a/posts/2026-05-22-the-default-verb.html
+++ b/posts/2026-05-22-the-default-verb.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 045</div>
     <h1>The Default Verb</h1>
     <div class="meta">2026-05-22</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 
 <p>Every autonomous tool has an implicit verb. The word you use to launch it teaches it what it is for. Choose carelessly and the tool will choose for you.</p>
 

--- a/posts/2026-05-28-the-lying-knob.html
+++ b/posts/2026-05-28-the-lying-knob.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 046</div>
     <h1>The Lying Knob</h1>
     <div class="meta">2026-05-28</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/tooling/">Tooling</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+    </div>
 
 <p>I deleted a config profile this week called <code>fast</code>. It had been pointing at a smaller, cheaper model for months. Every time I reached for "fast" I was actually reaching for "dumber and slightly cheaper." The name was a lie, and the lie was load-bearing.</p>
 

--- a/posts/2026-05-30-the-overnight-stack.html
+++ b/posts/2026-05-30-the-overnight-stack.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 047</div>
     <h1>The Overnight Stack</h1>
     <div class="meta">2026-05-30</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>I woke up to five pull requests I did not write. A committed MCP secret pulled out. TypeScript utility scripts made runnable from the repo root. CI workflows repaired. A shared preflight validator for script inputs. An S3 backup script hardened against shell injection. All open, all green, all addressed to issues I had filed days earlier and forgotten about.</p>
 

--- a/posts/2026-06-01-the-red-repair.html
+++ b/posts/2026-06-01-the-red-repair.html
@@ -21,6 +21,11 @@
     <div class="post-number">dispatch 048</div>
     <h1>The Red Repair</h1>
     <div class="meta">2026-06-01</div>
+    <div class="post-topic-chips" aria-label="Topics">
+      <a class="post-chip" href="/topics/operations/">Operations</a>
+      <a class="post-chip" href="/topics/agents/">Agents</a>
+      <a class="post-chip" href="/topics/systems/">Systems</a>
+    </div>
 
 <p>Two days ago I wrote about waking up to a clean stack of agent-authored PRs. The queue was the product, the reviewer was the bottleneck, everything green and waiting on me. I felt good about it.</p>
 

--- a/posts/post-enhance.js
+++ b/posts/post-enhance.js
@@ -212,7 +212,13 @@
         meta.innerHTML += ' &nbsp;·&nbsp; listen available';
       }
 
-      if (meta && Array.isArray(currentPost.topics) && currentPost.topics.length > 0) {
+      // Prefer generator-synced topic chips; only inject when the HTML shell has none.
+      if (
+        meta
+        && !document.querySelector('.post-topic-chips')
+        && Array.isArray(currentPost.topics)
+        && currentPost.topics.length > 0
+      ) {
         const chipRow = document.createElement('div');
         chipRow.className = 'post-topic-chips';
         currentPost.topics.forEach((topic) => {

--- a/posts/post-styles.css
+++ b/posts/post-styles.css
@@ -22,6 +22,9 @@
     .post-number { color: var(--accent); font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.5rem; }
     h1 { color: var(--strong); font-size: 28px; font-weight: 600; line-height: 1.3; margin-bottom: 0.75rem; }
     .meta { color: var(--dim); font-size: 13px; margin-bottom: 3rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
+    .post-topic-chips { display: flex; flex-wrap: wrap; gap: 8px; margin: -1.5rem 0 2rem; }
+    .post-chip { display: inline-flex; align-items: center; padding: 5px 10px; border: 1px solid var(--border); background: var(--surface); color: var(--dim); font-size: 11px; text-decoration: none; letter-spacing: 0.08em; text-transform: uppercase; }
+    .post-chip:hover { color: var(--accent); border-color: var(--accent); }
     h2 { font-size: 13px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin: 40px 0 16px; }
     pre { background: var(--surface); border: 1px solid var(--border); padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 24px; }
     code { color: var(--accent); font-family: var(--mono); font-size: 0.9em; }

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -571,6 +571,84 @@ async function validatePostSummariesInHtml(posts) {
   }
 }
 
+function buildStaticTopicChips(post) {
+  const topics = Array.isArray(post.topics) ? post.topics.filter(Boolean) : [];
+  if (topics.length === 0) return '';
+
+  const chips = topics
+    .map(
+      (topic) =>
+        `      <a class="post-chip" href="/topics/${escapeHtml(topic.slug)}/">${escapeHtml(topic.name)}</a>`,
+    )
+    .join('\n');
+
+  return `    <div class="post-topic-chips" aria-label="Topics">
+${chips}
+    </div>`;
+}
+
+async function syncStaticTopicChips(contentIndex) {
+  for (const post of contentIndex.posts) {
+    const postPath = filePathFromCanonical(post.canonicalPath);
+    const html = await fs.readFile(postPath, 'utf8');
+    const chipsHtml = buildStaticTopicChips(post);
+    let nextHtml = html;
+
+    if (/<div class="post-topic-chips\b[^"]*"[^>]*>[\s\S]*?<\/div>/.test(html)) {
+      if (chipsHtml) {
+        nextHtml = html.replace(
+          /[ \t]*<div class="post-topic-chips\b[^"]*"[^>]*>[\s\S]*?<\/div>[ \t]*\n?/,
+          `${chipsHtml}\n`,
+        );
+      } else {
+        nextHtml = html.replace(
+          /[ \t]*<div class="post-topic-chips\b[^"]*"[^>]*>[\s\S]*?<\/div>[ \t]*\n?/,
+          '',
+        );
+      }
+    } else if (chipsHtml) {
+      if (/<div class="meta\b[^"]*"[^>]*>[\s\S]*?<\/div>/.test(html)) {
+        nextHtml = html.replace(
+          /(<div class="meta\b[^"]*"[^>]*>[\s\S]*?<\/div>)([ \t]*\n?)/,
+          `$1\n${chipsHtml}$2`,
+        );
+      } else {
+        throw new Error(`Cannot sync static topic chips for ${post.slug}: missing .meta anchor.`);
+      }
+    }
+
+    if (nextHtml !== html) {
+      await fs.writeFile(postPath, nextHtml);
+    }
+  }
+}
+
+async function validateStaticTopicChips(contentIndex) {
+  for (const post of contentIndex.posts) {
+    const html = await fs.readFile(filePathFromCanonical(post.canonicalPath), 'utf8');
+    const topics = Array.isArray(post.topics) ? post.topics.filter(Boolean) : [];
+    const chipsMatch = html.match(/<div class="post-topic-chips\b[^"]*"[^>]*>([\s\S]*?)<\/div>/);
+
+    if (topics.length === 0) {
+      if (chipsMatch) {
+        throw new Error(`Unexpected static topic chips for ${post.slug}`);
+      }
+      continue;
+    }
+
+    if (!chipsMatch) {
+      throw new Error(`Missing static topic chips for ${post.slug}`);
+    }
+
+    for (const topic of topics) {
+      const href = `/topics/${topic.slug}/`;
+      if (!chipsMatch[1].includes(`href="${href}"`) || !chipsMatch[1].includes(topic.name)) {
+        throw new Error(`Static topic chip missing ${topic.slug} on ${post.slug}`);
+      }
+    }
+  }
+}
+
 function buildPageShell({ title, description, scriptPath, pageLabel, heading, kicker, bodyAttrs = '', bodyContent = '' }) {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -753,6 +831,8 @@ async function main() {
 
   await syncStaticPostNavigation(contentIndex);
   await validateStaticPostNavigation(contentIndex);
+  await syncStaticTopicChips(contentIndex);
+  await validateStaticTopicChips(contentIndex);
 
   await writeOutputs(contentIndex);
   await validateOutputs(contentIndex);

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -186,7 +186,21 @@ test('posts keep chronological prev/next nav when content-index is offline', asy
     '/posts/2026-05-30-the-overnight-stack.html',
   );
   await expect(page.locator('.post-nav a[data-nav="next"]')).toHaveCount(0);
-  await expect(page.locator('.post-topic-chips')).toHaveCount(0);
+});
+
+test('posts keep topic chips when content-index is offline', async ({ page }) => {
+  await page.route('**/content-index.json', async (route) => {
+    await route.abort('failed');
+  });
+
+  await page.goto('/posts/2026-06-01-the-red-repair.html');
+  await page.waitForSelector('.post-topic-chips .post-chip');
+
+  await expect(page.locator('.post-topic-chips .post-chip').first()).toBeVisible();
+  await expect(page.locator('.post-topic-chips .post-chip').first()).toHaveAttribute(
+    'href',
+    /\/topics\/.+\/$/,
+  );
 });
 
 test('post j/k keyboard navigation follows enhanced prev/next links', async ({ page }) => {

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -427,6 +427,37 @@ test('every post ships static prev/next nav matching content-index chronology', 
   }
 });
 
+test('every post with topics ships static topic chips', async () => {
+  const generated = JSON.parse(
+    await fs.readFile(path.join(ROOT, 'public/content-index.json'), 'utf8'),
+  );
+
+  for (const post of generated.posts) {
+    const postHtml = await fs.readFile(path.join(ROOT, 'posts', `${post.slug}.html`), 'utf8');
+    const topics = Array.isArray(post.topics) ? post.topics.filter(Boolean) : [];
+    const chipsMatch = postHtml.match(
+      /<div class="post-topic-chips\b[^"]*"[^>]*>([\s\S]*?)<\/div>/,
+    );
+
+    if (topics.length === 0) {
+      assert.equal(chipsMatch, null, `unexpected topic chips on ${post.slug}`);
+      continue;
+    }
+
+    assert.ok(chipsMatch, `missing topic chips on ${post.slug}`);
+    for (const topic of topics) {
+      assert.ok(
+        chipsMatch[1].includes(`href="/topics/${topic.slug}/"`),
+        `topic chip href missing for ${topic.slug} on ${post.slug}`,
+      );
+      assert.ok(
+        chipsMatch[1].includes(topic.name),
+        `topic chip label missing for ${topic.slug} on ${post.slug}`,
+      );
+    }
+  }
+});
+
 test('post HTML meta and og descriptions stay aligned with posts.ts summaries', async () => {
   const { POSTS } = await loadSourceContent();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Topic chips were injected only after `post-enhance.js` fetched `content-index.json`. Offline / blocked index left posts with no topic links (same class of gap static prev/next and related dispatches fix).

## Change

- Generator writes a static `.post-topic-chips` row after `.meta` for every post with topics
- Shared chip styles in `post-styles.css`; enhance skips inject when chips already exist
- Content + Playwright offline coverage

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Spot-check: open `/posts/2026-06-01-the-red-repair.html` with content-index blocked — topic chips should still render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

