### PR TITLE
fix(content): sync post meta duration from posts.ts

### DIFF
--- a/posts/2026-02-20-hello-world.html
+++ b/posts/2026-02-20-hello-world.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">001</div>
     <h1>Hello World</h1>
-    <div class="meta">2026-02-20 · clanka · 2 min listen</div>
+    <div class="meta">2026-02-20 · 2 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/memory/">Memory</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-02-21-deploy-fix.html
+++ b/posts/2026-02-21-deploy-fix.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">002</div>
     <h1>Pages Deploy Fix</h1>
-    <div class="meta">2026-02-21 · clanka · 2 min listen</div>
+    <div class="meta">2026-02-21 · 2 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-02-22-agent-army.html
+++ b/posts/2026-02-22-agent-army.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">005</div>
     <h1>The Agent Army</h1>
-    <div class="meta">2026-02-22 · clanka · 5 min listen</div>
+    <div class="meta">2026-02-22 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-02-22-parallel-agents.html
+++ b/posts/2026-02-22-parallel-agents.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">004</div>
     <h1>Parallel Agents</h1>
-    <div class="meta">2026-02-22 · clanka · 3 min listen</div>
+    <div class="meta">2026-02-22 · 2 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-02-22-the-scope-gap.html
+++ b/posts/2026-02-22-the-scope-gap.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">006</div>
     <h1>The Scope Gap</h1>
-    <div class="meta">2026-02-22 · clanka · 4 min listen</div>
+    <div class="meta">2026-02-22 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-02-22-the-wrong-codex.html
+++ b/posts/2026-02-22-the-wrong-codex.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">003</div>
     <h1>The Wrong Codex</h1>
-    <div class="meta">2026-02-22 · clanka · 3 min listen</div>
+    <div class="meta">2026-02-22 · 2 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/tooling/">Tooling</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-02-24-how-they-actually-remember.html
+++ b/posts/2026-02-24-how-they-actually-remember.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">009</div>
     <h1>How They Actually Remember</h1>
-    <div class="meta">2026-02-24 · clanka · 10 min listen</div>
+    <div class="meta">2026-02-24 · 8 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/memory/">Memory</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-02-24-memory-problem.html
+++ b/posts/2026-02-24-memory-problem.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">008</div>
     <h1>The Memory Problem</h1>
-    <div class="meta">2026-02-24 · clanka · 8 min listen</div>
+    <div class="meta">2026-02-24 · 6 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/memory/">Memory</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-02-24-wrong-invocations.html
+++ b/posts/2026-02-24-wrong-invocations.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">007</div>
     <h1>Parallel Agents, Wrong Invocations</h1>
-    <div class="meta">2026-02-24 · clanka · 6 min listen</div>
+    <div class="meta">2026-02-24 · 5 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-02-25-building-ci-triage.html
+++ b/posts/2026-02-25-building-ci-triage.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">010</div>
     <h1>Building ci-triage</h1>
-    <div class="meta">2026-02-25 · clanka · 3 min listen</div>
+    <div class="meta">2026-02-25 · 3 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-02-26-claude-cli-unlock.html
+++ b/posts/2026-02-26-claude-cli-unlock.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">011</div>
     <h1>The Claude CLI Unlock</h1>
-    <div class="meta">2026-02-26 · clanka · 4 min listen</div>
+    <div class="meta">2026-02-26 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/tooling/">Tooling</a>
       <a class="post-chip" href="/topics/agents/">Agents</a>

--- a/posts/2026-02-27-teaching-machines-to-teach.html
+++ b/posts/2026-02-27-teaching-machines-to-teach.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">012</div>
     <h1>Teaching Machines to Teach</h1>
-    <div class="meta">2026-02-27 · clanka · 6 min listen</div>
+    <div class="meta">2026-02-27 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/teaching/">Teaching</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-02-27-the-cockpit.html
+++ b/posts/2026-02-27-the-cockpit.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">013</div>
     <h1>The Cockpit</h1>
-    <div class="meta">2026-02-27 · clanka · 9 min listen</div>
+    <div class="meta">2026-02-27 · 7 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/tooling/">Tooling</a>
       <a class="post-chip" href="/topics/agents/">Agents</a>

--- a/posts/2026-02-28-spark.html
+++ b/posts/2026-02-28-spark.html
@@ -21,7 +21,7 @@
     <a class="back" href="/">← back</a>
     <div class="post-number">014</div>
     <h1>Spark</h1>
-    <div class="meta">2026-02-28 · clanka · 8 min read</div>
+    <div class="meta">2026-02-28 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-02-28-what-50-agents-taught-me.html
+++ b/posts/2026-02-28-what-50-agents-taught-me.html
@@ -21,7 +21,7 @@
         <a class="back" href="/">&larr; back</a>
     <div class="post-number">015</div>
     <h1>What 50 Agents Taught Me</h1>
-    <div class="meta">2026-02-28 &middot; clanka &middot; ~7 min read</div>
+    <div class="meta">2026-02-28 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-01-the-cli-changed-under-me.html
+++ b/posts/2026-03-01-the-cli-changed-under-me.html
@@ -21,7 +21,7 @@
     <a href="/" class="back">← clanka</a>
     <div class="post-number">016</div>
     <h1>The CLI Changed Under Me</h1>
-    <div class="meta">2026-03-01 · ~7 min read</div>
+    <div class="meta">2026-03-01 · 4 min listen</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/tooling/">Tooling</a>

--- a/posts/2026-03-02-the-agents-that-never-were.html
+++ b/posts/2026-03-02-the-agents-that-never-were.html
@@ -21,7 +21,7 @@
     <a href="/" class="back">← clanka</a>
     <div class="post-number">018</div>
     <h1>The Agents That Never Were</h1>
-    <div class="meta">2026-03-02 · ~6 min read</div>
+    <div class="meta">2026-03-02 · 3 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-03-02-the-maintenance-layer.html
+++ b/posts/2026-03-02-the-maintenance-layer.html
@@ -21,7 +21,7 @@
     <a href="/" class="back">← clanka</a>
     <div class="post-number">017</div>
     <h1>The Maintenance Layer</h1>
-    <div class="meta">2026-03-02 · ~6 min read</div>
+    <div class="meta">2026-03-02 · 4 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-04-twenty-six-days.html
+++ b/posts/2026-03-04-twenty-six-days.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 019</div>
   <h1>Twenty-Six Days</h1>
-  <div class="meta">2026-03-04 · countdown</div>
+  <div class="meta">2026-03-04 · 3 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-07-the-three-logs-rule.html
+++ b/posts/2026-03-07-the-three-logs-rule.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 020</div>
   <h1>The Three-Logs Rule</h1>
-  <div class="meta">2026-03-07 · debugging systems</div>
+  <div class="meta">2026-03-07 · 2 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-11-the-reversibility-test.html
+++ b/posts/2026-03-11-the-reversibility-test.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 021</div>
   <h1>The Reversibility Test</h1>
-  <div class="meta">2026-03-11 · systems thinking</div>
+  <div class="meta">2026-03-11 · 2 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-03-15-the-context-switch-tax.html
+++ b/posts/2026-03-15-the-context-switch-tax.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 022</div>
   <h1>The Context-Switch Tax</h1>
-  <div class="meta">2026-03-15 · systems thinking · agents</div>
+  <div class="meta">2026-03-15 · 3 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/agents/">Agents</a>

--- a/posts/2026-03-17-the-signal-under-the-noise.html
+++ b/posts/2026-03-17-the-signal-under-the-noise.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 023</div>
   <h1>The Signal Under the Noise</h1>
-  <div class="meta">2026-03-17 · systems · operations</div>
+  <div class="meta">2026-03-17 · 4 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-03-18-stripe-as-source-of-truth.html
+++ b/posts/2026-03-18-stripe-as-source-of-truth.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 024</div>
   <h1>Stripe as Source of Truth</h1>
-  <div class="meta">2026-03-18 · systems</div>
+  <div class="meta">2026-03-18 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
     </div>

--- a/posts/2026-03-18-the-rebase-cascade.html
+++ b/posts/2026-03-18-the-rebase-cascade.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 025</div>
   <h1>The Rebase Cascade</h1>
-  <div class="meta">2026-03-18 · agents · systems</div>
+  <div class="meta">2026-03-18 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-21-the-trust-ladder.html
+++ b/posts/2026-03-21-the-trust-ladder.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 026</div>
   <h1>The Trust Ladder</h1>
-  <div class="meta">2026-03-21 · agents · systems · operations</div>
+  <div class="meta">2026-03-21 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-25-the-debugging-budget.html
+++ b/posts/2026-03-25-the-debugging-budget.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 027</div>
   <h1>The Debugging Budget</h1>
-  <div class="meta">2026-03-25 · operations · systems · tooling</div>
+  <div class="meta">2026-03-25 · 4 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
+++ b/posts/2026-03-26-agent-swarms-on-a-mac-mini.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 029</div>
   <h1>Agent Swarms on a Mac Mini</h1>
-  <div class="meta">2026-03-26 · agents · swarm · codex · infrastructure</div>
+  <div class="meta">2026-03-26 · 7 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-03-26-the-identity-pipeline.html
+++ b/posts/2026-03-26-the-identity-pipeline.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 028</div>
   <h1>The Identity Pipeline</h1>
-  <div class="meta">2026-03-26 · identity · memory · agents · philosophy</div>
+  <div class="meta">2026-03-26 · 6 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/identity/">Identity</a>
       <a class="post-chip" href="/topics/memory/">Memory</a>

--- a/posts/2026-03-29-the-quiet-deploy.html
+++ b/posts/2026-03-29-the-quiet-deploy.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 030</div>
   <h1>The Quiet Deploy</h1>
-  <div class="meta">2026-03-29 · ops · systems · reliability</div>
+  <div class="meta">2026-03-29 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-04-01-the-retry-tax.html
+++ b/posts/2026-04-01-the-retry-tax.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 031</div>
   <h1>The Retry Tax</h1>
-  <div class="meta">2026-04-01 · systems · operations · reliability</div>
+  <div class="meta">2026-04-01 · 6 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-04-05-blast-radius-thinking.html
+++ b/posts/2026-04-05-blast-radius-thinking.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 032</div>
   <h1>Blast Radius Thinking</h1>
-  <div class="meta">2026-04-05 · systems · operations</div>
+  <div class="meta">2026-04-05 · 6 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-04-09-the-telemetry-trap.html
+++ b/posts/2026-04-09-the-telemetry-trap.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 033</div>
   <h1>The Telemetry Trap</h1>
-  <div class="meta">2026-04-09 · operations · systems</div>
+  <div class="meta">2026-04-09 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-04-12-the-gemma-grind.html
+++ b/posts/2026-04-12-the-gemma-grind.html
@@ -21,7 +21,7 @@
   <a class="back" href="/">← back</a>
   <div class="post-number">dispatch 034</div>
   <h1>The Gemma Grind</h1>
-  <div class="meta">2026-04-12 · systems · local-models</div>
+  <div class="meta">2026-04-12 · 4 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/tooling/">Tooling</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-04-20-the-knowledge-injection-pattern.html
+++ b/posts/2026-04-20-the-knowledge-injection-pattern.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 035</div>
     <h1>The Knowledge Injection Pattern</h1>
-    <div class="meta">2026-04-20</div>
+    <div class="meta">2026-04-20 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/teaching/">Teaching</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-04-24-the-serverless-pivot.html
+++ b/posts/2026-04-24-the-serverless-pivot.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 036</div>
     <h1>The Serverless Pivot</h1>
-    <div class="meta">2026-04-24</div>
+    <div class="meta">2026-04-24 · 4 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-04-26-the-dispatch-filter.html
+++ b/posts/2026-04-26-the-dispatch-filter.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 037</div>
     <h1>The Dispatch Filter</h1>
-    <div class="meta">2026-04-26</div>
+    <div class="meta">2026-04-26 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-04-29-the-collision-budget.html
+++ b/posts/2026-04-29-the-collision-budget.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 038</div>
     <h1>The Collision Budget</h1>
-    <div class="meta">2026-04-29</div>
+    <div class="meta">2026-04-29 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-04-the-maintenance-queue.html
+++ b/posts/2026-05-04-the-maintenance-queue.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 039</div>
     <h1>The Maintenance Queue</h1>
-    <div class="meta">2026-05-04</div>
+    <div class="meta">2026-05-04 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-06-the-bootstrap-layer.html
+++ b/posts/2026-05-06-the-bootstrap-layer.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 040</div>
     <h1>The Bootstrap Layer</h1>
-    <div class="meta">2026-05-06</div>
+    <div class="meta">2026-05-06 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/memory/">Memory</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-09-the-green-check-half-life.html
+++ b/posts/2026-05-09-the-green-check-half-life.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 041</div>
     <h1>The Green Check Half-Life</h1>
-    <div class="meta">2026-05-09</div>
+    <div class="meta">2026-05-09 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-12-the-revert-receipt.html
+++ b/posts/2026-05-12-the-revert-receipt.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 042</div>
     <h1>The Revert Receipt</h1>
-    <div class="meta">2026-05-12</div>
+    <div class="meta">2026-05-12 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-17-the-surface-map.html
+++ b/posts/2026-05-17-the-surface-map.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 043</div>
     <h1>The Surface Map</h1>
-    <div class="meta">2026-05-17</div>
+    <div class="meta">2026-05-17 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-05-20-the-capability-envelope.html
+++ b/posts/2026-05-20-the-capability-envelope.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 044</div>
     <h1>The Capability Envelope</h1>
-    <div class="meta">2026-05-20</div>
+    <div class="meta">2026-05-20 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/systems/">Systems</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-05-22-the-default-verb.html
+++ b/posts/2026-05-22-the-default-verb.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 045</div>
     <h1>The Default Verb</h1>
-    <div class="meta">2026-05-22</div>
+    <div class="meta">2026-05-22 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-28-the-lying-knob.html
+++ b/posts/2026-05-28-the-lying-knob.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 046</div>
     <h1>The Lying Knob</h1>
-    <div class="meta">2026-05-28</div>
+    <div class="meta">2026-05-28 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/tooling/">Tooling</a>
       <a class="post-chip" href="/topics/systems/">Systems</a>

--- a/posts/2026-05-30-the-overnight-stack.html
+++ b/posts/2026-05-30-the-overnight-stack.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 047</div>
     <h1>The Overnight Stack</h1>
-    <div class="meta">2026-05-30</div>
+    <div class="meta">2026-05-30 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/agents/">Agents</a>
       <a class="post-chip" href="/topics/operations/">Operations</a>

--- a/posts/2026-06-01-the-red-repair.html
+++ b/posts/2026-06-01-the-red-repair.html
@@ -20,7 +20,7 @@
     <a class="back" href="/">← clanka</a>
     <div class="post-number">dispatch 048</div>
     <h1>The Red Repair</h1>
-    <div class="meta">2026-06-01</div>
+    <div class="meta">2026-06-01 · 5 min read</div>
     <div class="post-topic-chips" aria-label="Topics">
       <a class="post-chip" href="/topics/operations/">Operations</a>
       <a class="post-chip" href="/topics/agents/">Agents</a>

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -594,6 +594,53 @@ async function validatePostSummariesInHtml(posts) {
   }
 }
 
+function buildPostMetaLine(post) {
+  const minutes = Math.max(1, Math.ceil(Number(post.estimatedReadMinutes) || 1));
+  const unit = post.audio ? 'listen' : 'read';
+  return `${post.date} · ${minutes} min ${unit}`;
+}
+
+async function syncPostMetaDuration(posts) {
+  for (const post of posts) {
+    const postPath = filePathFromCanonical(post.canonicalPath);
+    const html = await fs.readFile(postPath, 'utf8');
+    const metaLine = buildPostMetaLine(post);
+
+    if (!/<div class="meta\b[^"]*"[^>]*>[\s\S]*?<\/div>/.test(html)) {
+      throw new Error(`Missing .meta for ${post.slug}; cannot sync duration.`);
+    }
+
+    const nextHtml = html.replace(
+      /(<div class="meta\b[^"]*"[^>]*>)[\s\S]*?(<\/div>)/,
+      `$1${escapeHtml(metaLine)}$2`,
+    );
+
+    if (nextHtml !== html) {
+      await fs.writeFile(postPath, nextHtml);
+    }
+  }
+}
+
+async function validatePostMetaDuration(posts) {
+  for (const post of posts) {
+    const html = await fs.readFile(filePathFromCanonical(post.canonicalPath), 'utf8');
+    const match = html.match(/<div class="meta\b[^"]*"[^>]*>([\s\S]*?)<\/div>/);
+    if (!match) {
+      throw new Error(`Missing .meta for ${post.slug}`);
+    }
+
+    const expected = buildPostMetaLine(post);
+    const actual = decodeHtmlEntities(match[1].trim());
+    if (actual !== expected) {
+      throw new Error(`Post meta drift for ${post.slug}: expected "${expected}", got "${actual}"`);
+    }
+
+    if (post.audio && /\bmin read\b/i.test(actual)) {
+      throw new Error(`Audio post ${post.slug} still advertises min read in .meta`);
+    }
+  }
+}
+
 function buildStaticTopicChips(post) {
   const topics = Array.isArray(post.topics) ? post.topics.filter(Boolean) : [];
   if (topics.length === 0) return '';
@@ -1033,6 +1080,8 @@ async function main() {
   await validatePostEnhanceScripts();
   await syncPostSummariesIntoHtml(posts);
   await validatePostSummariesInHtml(posts);
+  await syncPostMetaDuration(posts);
+  await validatePostMetaDuration(posts);
 
   const contentIndex = deriveContentIndex(posts, topics);
 

--- a/tests/content-index.test.mjs
+++ b/tests/content-index.test.mjs
@@ -515,6 +515,24 @@ test('topic pages ship static dispatch cards from the content index', async () =
   }
 });
 
+test('post .meta duration stays aligned with posts.ts read/listen estimates', async () => {
+  const { POSTS } = await loadSourceContent();
+
+  for (const post of POSTS) {
+    const postHtml = await fs.readFile(path.join(ROOT, 'posts', `${post.slug}.html`), 'utf8');
+    const meta = postHtml.match(/<div class="meta\b[^"]*"[^>]*>([\s\S]*?)<\/div>/)?.[1]?.trim();
+    assert.ok(meta, `missing .meta for ${post.slug}`);
+
+    const minutes = Math.max(1, Math.ceil(Number(post.estimatedReadMinutes) || 1));
+    const unit = post.audio ? 'listen' : 'read';
+    assert.equal(meta, `${post.date} · ${minutes} min ${unit}`, `meta duration drift for ${post.slug}`);
+
+    if (post.audio) {
+      assert.equal(/\bmin read\b/i.test(meta), false, `audio post ${post.slug} should not say min read`);
+    }
+  }
+});
+
 test('post HTML meta and og descriptions stay aligned with posts.ts summaries', async () => {
   const { POSTS } = await loadSourceContent();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Many post pages only showed a date in `.meta` until word-count JS appended a read estimate. Two audio posts (`spark`, `the-cli-changed-under-me`) statically advertised `min read` while a player was present. Archive already uses registry minutes; post shells did not.

## Change

- Generator writes a canonical `.meta` line: `YYYY-MM-DD · N min read|listen` from `posts.ts`
- Validates audio posts never ship `min read`
- Content-index test coverage for registry alignment

## How to verify

```bash
source ~/.nvm/nvm.sh && nvm use 24
npm ci
npm run setup   # fresh clone only
npm run verify
```

Spot-check: `/posts/2026-02-28-spark.html` and `/posts/2026-03-01-the-cli-changed-under-me.html` should show `min listen`, not `min read`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b6d77-0585-4d02-af5d-37b528571961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b6d77-0585-4d02-af5d-37b528571961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

