### PR TITLE
fix(status): mute live pulse when SITE/OFFLINE/STALE

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="syncing"></span>
     <span id="status-live-label">SYNCING</span>
   </span>
 </div>

--- a/logs/index.html
+++ b/logs/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/scripts/generate-site-content.mjs
+++ b/scripts/generate-site-content.mjs
@@ -844,7 +844,7 @@ function buildPageShell({ title, description, scriptPath, pageLabel, heading, ki
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -167,10 +167,36 @@ body::after {
 .status-live-dot {
   width: 6px;
   height: 6px;
-  background: #22c55e;
   border-radius: 50%;
+  background: var(--dim, #3a3a42);
+  box-shadow: none;
+  animation: none;
+  opacity: 0.55;
+}
+
+/* Only LIVE keeps the green pulse — SITE/OFFLINE/STALE must not look live. */
+.status-live-dot[data-state='live'] {
+  background: #22c55e;
   animation: livePulse 1.4s ease-in-out infinite;
   box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+  opacity: 1;
+}
+
+.status-live-dot[data-state='syncing'] {
+  background: #eab308;
+  animation: livePulse 1.4s ease-in-out infinite;
+  box-shadow: 0 0 6px rgba(234, 179, 8, 0.35);
+  opacity: 1;
+}
+
+.status-live-dot[data-state='stale'] {
+  background: #eab308;
+  opacity: 0.55;
+}
+
+.status-live-dot[data-state='offline'] {
+  background: #ef4444;
+  opacity: 0.55;
 }
 
 #theme-toggle {

--- a/src/ui-scripts.ts
+++ b/src/ui-scripts.ts
@@ -121,29 +121,33 @@ export function initUI(): void {
     const liveDot = document.getElementById('status-live-dot') as HTMLElement | null;
     if (!liveLabel) return;
 
-    const setLiveState = (label: string, offline: boolean): void => {
+    const setLiveState = (label: string): void => {
       liveLabel.textContent = label;
       if (liveDot) {
-        liveDot.style.opacity = offline ? '0.35' : '';
+        liveDot.dataset.state = label.toLowerCase();
       }
     };
+
+    // Apply chrome for the HTML-seeded label immediately (SITE on archive/topic shells).
+    const seeded = (liveLabel.textContent || 'SITE').trim().toUpperCase();
+    setLiveState(seeded || 'SITE');
 
     const presence = document.getElementById('presence');
     if (!presence) {
       // Archive/topic shells have no telemetry presence widget.
-      if (liveLabel.textContent === 'SYNCING' || liveLabel.textContent === 'LIVE') {
-        setLiveState('SITE', false);
+      if (seeded === 'SYNCING' || seeded === 'LIVE') {
+        setLiveState('SITE');
       }
       return;
     }
 
     presence.addEventListener('sync-updated', () => {
-      setLiveState('LIVE', false);
+      setLiveState('LIVE');
     });
     presence.addEventListener('sync-error', (event: Event) => {
       const hadSync = Boolean((event as CustomEvent<{ hadSync?: boolean }>).detail?.hadSync);
       // Match presence chrome: keep last-good live data as STALE, not OFFLINE.
-      setLiveState(hadSync ? 'STALE' : 'OFFLINE', true);
+      setLiveState(hadSync ? 'STALE' : 'OFFLINE');
     });
   })();
 

--- a/tests/archive.spec.ts
+++ b/tests/archive.spec.ts
@@ -298,6 +298,9 @@ test('archive status bar does not claim LIVE telemetry', async ({ page }) => {
   await page.goto('/logs/');
   await page.waitForSelector('#archive-search-input');
   await expect(page.locator('#status-live-label')).toHaveText('SITE');
+  // Dot chrome must match SITE — no green live pulse on archive shells.
+  await expect(page.locator('#status-live-dot')).toHaveAttribute('data-state', 'site');
+  await expect(page.locator('#status-live-dot')).not.toHaveCSS('animation-name', 'livePulse');
 });
 
 test('migrated featured post ships shared styles and social metadata', async ({ page }) => {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -385,6 +385,7 @@ test('live widgets show offline state when API is unreachable', async ({ page })
 
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: offline');
   await expect(page.locator('#status-live-label')).toHaveText('OFFLINE');
+  await expect(page.locator('#status-live-dot')).toHaveAttribute('data-state', 'offline');
   await expect(page.locator('clanka-agents#agents')).toContainText('[ api unreachable ]');
   await expect(page.locator('clanka-tasks#tasks')).toContainText('[ api unreachable ]');
 
@@ -503,6 +504,7 @@ test('transient sync-error after a successful sync keeps task boards visible', a
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 2 active');
   // Status chrome should mirror presence STALE, not jump to OFFLINE after a prior sync.
   await expect(page.locator('#status-live-label')).toHaveText('STALE');
+  await expect(page.locator('#status-live-dot')).toHaveAttribute('data-state', 'stale');
 });
 
 

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -147,6 +147,7 @@ test('homepage does not mount a duplicate activity widget', async ({ page }) => 
 test('active agent stat is populated from live now payload', async ({ page }) => {
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 7 active');
   await expect(page.locator('#status-live-label')).toHaveText('LIVE');
+  await expect(page.locator('#status-live-dot')).toHaveAttribute('data-state', 'live');
 });
 
 test('homepage repo stats are populated from mocked API responses', async ({ page }) => {

--- a/topics/agents/index.html
+++ b/topics/agents/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/identity/index.html
+++ b/topics/identity/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/memory/index.html
+++ b/topics/memory/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/operations/index.html
+++ b/topics/operations/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/philosophy/index.html
+++ b/topics/philosophy/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/systems/index.html
+++ b/topics/systems/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/teaching/index.html
+++ b/topics/teaching/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>

--- a/topics/tooling/index.html
+++ b/topics/tooling/index.html
@@ -33,7 +33,7 @@
 <div id="status-bar" role="status" aria-live="polite">
   <span id="status-left">CLANKA · ⚡ clankamode.github.io · <span id="status-date"></span></span>
   <span class="status-live">
-    <span class="status-live-dot" id="status-live-dot"></span>
+    <span class="status-live-dot" id="status-live-dot" data-state="site"></span>
     <span id="status-live-label">SITE</span>
   </span>
 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Status-bar dot no longer always looks “live”: only `LIVE` keeps the green pulse; `SITE` / `OFFLINE` / `STALE` / `SYNCING` use honest chrome via `data-state`.
- Archive/topic shells seed `data-state="site"` so they don’t flash a green heartbeat with no telemetry.
- Tests assert `data-state` for LIVE / OFFLINE / STALE / SITE.

## Test plan
- [x] `npm run typecheck`
- [x] Playwright: archive SITE chrome, homepage LIVE, offline OFFLINE, stale STALE
- [ ] Spot-check `/` and `/logs/` — pulse only when label is LIVE
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83286df0-e272-4d59-88ee-276519383b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83286df0-e272-4d59-88ee-276519383b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

