### PR TITLE
fix(presence): stop inventing active/operational signals

### DIFF
--- a/src/clanka-presence.ts
+++ b/src/clanka-presence.ts
@@ -6,7 +6,7 @@ import { withRetries } from './retry';
 @customElement('clanka-presence')
 export class ClankaPresence extends LitElement {
   @state() private current: string = '[ loading... ]';
-  @state() private status: string = 'OPERATIONAL';
+  @state() private status: string = '';
   @state() private loading = true;
   @state() private error = '';
   @state() private stale = false;
@@ -160,13 +160,14 @@ export class ClankaPresence extends LitElement {
       if (current.length > 0) {
         this.current = current;
       } else if (!this.hasSyncedOnce) {
-        this.current = 'active';
+        // Do not invent ops copy — blank current means the API sent no signal.
+        this.current = '[ no current signal ]';
       }
       const status = typeof data.status === 'string' ? data.status.trim() : '';
       if (status.length > 0) {
         this.status = status;
       } else if (!this.hasSyncedOnce) {
-        this.status = 'operational';
+        this.status = 'unknown';
       }
       this.error = '';
       this.stale = false;
@@ -204,7 +205,7 @@ export class ClankaPresence extends LitElement {
       ? 'SYNCING'
       : this.stale
         ? 'STALE'
-        : this.status.toUpperCase();
+        : (this.status || 'unknown').toUpperCase();
 
     return html`
       <div class="hd">

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -561,10 +561,31 @@ test('presence announces status via aria-live and rejects blank current', async 
   const presence = page.locator('clanka-presence#presence');
   await expect(presence.locator('.hd-status')).toHaveAttribute('aria-live', 'polite');
   await expect(presence.locator('.presence-block')).toHaveAttribute('aria-live', 'polite');
-  // Blank current falls back on first sync; status still applies.
+  // Blank current stays honest — no invented "active" ops copy; status still applies.
   await expect(presence.locator('.hd-status')).toContainText('THINKING');
-  await expect(presence.locator('.presence-block')).toContainText('active');
+  await expect(presence.locator('.presence-block')).toContainText('[ no current signal ]');
+  await expect(presence.locator('.presence-block')).not.toContainText('active');
   await expect(presence.locator('.presence-block')).not.toContainText('[ api unreachable ]');
+});
+
+test('presence does not invent operational status when /now omits it', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'shipping honesty fixes',
+        status: '   ',
+        agents_active: 1,
+      }),
+    });
+  });
+
+  await page.reload();
+  const presence = page.locator('clanka-presence#presence');
+  await expect(presence.locator('.presence-block')).toContainText('shipping honesty fixes');
+  await expect(presence.locator('.hd-status')).toContainText('UNKNOWN');
+  await expect(presence.locator('.hd-status')).not.toContainText('OPERATIONAL');
 });
 
 test('slim sync after offline clears latched agent offline state', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Blank `/now` `current` no longer falls back to fabricated `active`.
- Missing/blank `status` shows `UNKNOWN` instead of inventing `operational`.
- Keeps real status (e.g. `THINKING`) when the API sends it.

## Test plan
- [x] `npm run typecheck`
- [x] Playwright: blank current → `[ no current signal ]`; omitted status → `UNKNOWN`
- [ ] Homepage with mocked sparse `/now` — presence copy matches payload honesty
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83286df0-e272-4d59-88ee-276519383b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83286df0-e272-4d59-88ee-276519383b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

