### PR TITLE
fix(fleet): label one-shot registry fetch as SYNCED

### DIFF
--- a/src/clanka-fleet.ts
+++ b/src/clanka-fleet.ts
@@ -287,13 +287,13 @@ export class ClankaFleet extends LitElement {
   private get syncLabel(): string {
     if (this.loading) return 'SYNCING';
     if (!this.live) return 'OFFLINE';
-    if (!this.repos.length) return 'SYNCED';
-    return this.repos.some((repo) => repo.online !== null) ? 'LIVE' : 'SYNCED';
+    // One-shot near-viewport fetch — SYNCED, not LIVE (no poll/revalidate).
+    return 'SYNCED';
   }
 
   private get syncClass(): string {
     if (this.loading || !this.live) return '';
-    return this.repos.some((repo) => repo.online !== null) ? 'live' : 'synced';
+    return 'synced';
   }
 
   private extractRepos(data: unknown): { repos: FleetRepo[]; sourceCount: number } {

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -219,7 +219,10 @@ test('fleet widget renders mocked repo cards', async ({ page }) => {
   const fleet = page.locator('clanka-fleet#fleet');
   await fleet.scrollIntoViewIfNeeded();
   await expect(fleet.locator('.repo')).toHaveCount(2);
-  await expect(fleet.locator('.sync.live')).toBeVisible();
+  // One-shot load is SYNCED — not LIVE (no continuous refresh).
+  await expect(fleet.locator('.sync.synced')).toBeVisible();
+  await expect(fleet.locator('.sync')).toHaveText('SYNCED');
+  await expect(fleet.locator('.sync.live')).toHaveCount(0);
   await expect(fleet.locator('.status-pill.online')).toHaveCount(2);
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fleet registry is a one-shot near-viewport fetch with no poll/revalidate path.
- Successful loads now show `SYNCED` instead of `LIVE`, so the badge matches freshness.
- Repo online pills are unchanged; only the sync label/chrome is honest.

## Test plan
- [x] `npm run typecheck`
- [x] Playwright fleet card / invalid / omitted-online cases
- [ ] Scroll fleet into view on `/` — badge reads SYNCED, not LIVE
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83286df0-e272-4d59-88ee-276519383b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83286df0-e272-4d59-88ee-276519383b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

