### PR TITLE
fix(nav): expose Now in the command palette

### DIFF
--- a/src/clanka-cmdk.ts
+++ b/src/clanka-cmdk.ts
@@ -346,6 +346,7 @@ export class ClankaCmdk extends LitElement {
       { label: 'Work', hint: 'projects', href: '/#work-label', section: 'navigate' },
       { label: 'About', hint: 'bio', href: '/#about-label', section: 'navigate' },
       { label: 'Capabilities', hint: 'skills', href: '/#cap-label', section: 'navigate' },
+      { label: 'Now', hint: 'current focus', href: '/now.html', section: 'navigate' },
       { label: 'Archive', hint: 'all dispatches', href: '/logs/', section: 'logs' },
       { label: 'GitHub', hint: 'github.com/clankamode', href: 'https://github.com/clankamode', section: 'links' },
       { label: 'RSS Feed', hint: 'subscribe', href: '/feed.xml', section: 'links' },

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -111,6 +111,28 @@ test('command palette opens with meta+k and navigates to archive', async ({ page
   await expect(page.locator('#archive-search-input')).toBeVisible();
 });
 
+test('command palette navigates to Now', async ({ page }) => {
+  await page.keyboard.press('Meta+k');
+  const palette = page.locator('clanka-cmdk .palette');
+  await expect(palette).toBeVisible();
+
+  const input = palette.locator('input');
+  await input.fill('now');
+  // Prefer the navigate item (href /now.html), not a post titled something with "now".
+  await page.evaluate(() => {
+    const host = document.querySelector('clanka-cmdk') as HTMLElement & {
+      shadowRoot: ShadowRoot | null;
+    };
+    const option = Array.from(host.shadowRoot?.querySelectorAll('.item') ?? []).find((el) =>
+      el.querySelector('.item-label')?.textContent?.trim() === 'Now',
+    ) as HTMLElement | undefined;
+    option?.click();
+  });
+
+  await expect(page).toHaveURL(/\/now\.html$/);
+  await expect(page.getByRole('heading', { level: 1, name: /Current\s+signal/i })).toBeVisible();
+});
+
 test('command palette restores skip-link tab order after close', async ({ page }) => {
   const skip = page.locator('.skip-link');
   await expect(skip).toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- ⌘K navigate list now includes **Now** → `/now.html` (same destination as footer/404 links).
- Keyboard users can reach current-focus without hunting the footer.

## Test plan
- [x] `npm run typecheck`
- [x] Playwright: palette → Now lands on `/now.html` with the page H1
- [ ] Open ⌘K, type `now`, confirm navigate item and destination
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83286df0-e272-4d59-88ee-276519383b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83286df0-e272-4d59-88ee-276519383b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

