### PR TITLE
fix(agents): surface agents_active 0 when roster is empty

### DIFF
--- a/src/clanka-agents.ts
+++ b/src/clanka-agents.ts
@@ -72,7 +72,7 @@ export class ClankaAgents extends LitElement {
             : teamCount > 0
               ? html`// team: ${teamCount} member${teamCount === 1 ? '' : 's'}${active !== null ? html`<br>// ${active} active` : ''}<br>
                   // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`
-              : active !== null && active > 0
+              : active !== null
                 ? html`// ${active} active · roster unavailable<br>
                     // check <a href="https://github.com/clankamode" target="_blank" rel="noopener noreferrer">github.com/clankamode</a> for shipped work`
                 : html`// agent orchestration is internal<br>

--- a/tests/cmdk-offline.spec.ts
+++ b/tests/cmdk-offline.spec.ts
@@ -436,6 +436,27 @@ test('agents widget shows agents_active when roster is empty', async ({ page }) 
   await expect(page.locator('#stat-active-agents')).toHaveText('agents: 3 active');
 });
 
+test('agents widget treats agents_active 0 as a real signal when roster is empty', async ({ page }) => {
+  await page.route(`${API_BASE}/now`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        current: 'idle watch',
+        status: 'operational',
+        agents_active: 0,
+        team: {},
+      }),
+    });
+  });
+
+  await page.goto('/');
+  const agents = page.locator('clanka-agents#agents');
+  await expect(agents.locator('.note')).toContainText('0 active · roster unavailable');
+  await expect(agents.locator('.note')).not.toContainText('agent orchestration is internal');
+  await expect(page.locator('#stat-active-agents')).toHaveText('agents: 0 active');
+});
+
 test('partial /now payloads do not wipe tasks or agents', async ({ page }) => {
   await page.route(`${API_BASE}/now`, async (route) => {
     await route.fulfill({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Empty roster + `agents_active: 0` now shows `0 active · roster unavailable`.
- Only omitted `agents_active` keeps the “orchestration is internal” copy.
- Matches the honesty path already used for `agents_active > 0`.

## Test plan
- [x] `npm run typecheck`
- [x] Playwright: empty roster with `agents_active: 0` and `3`
- [ ] Homepage with mocked `/now` `{ agents_active: 0, team: {} }`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83286df0-e272-4d59-88ee-276519383b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83286df0-e272-4d59-88ee-276519383b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

